### PR TITLE
Add DM message reply UI and single-level reply flow

### DIFF
--- a/docs/message-replies-frontend-notes.md
+++ b/docs/message-replies-frontend-notes.md
@@ -1,0 +1,83 @@
+# Message replies frontend notes
+
+## Files and responsibilities
+- `src/store/slices/message.slice.ts`
+  - Stores `replyTarget` (`messageId`, `authorDisplayName`, `snippet`, `deleted`).
+  - Provides reply actions: `startReply`, `cancelReply`.
+  - Resets reply target on room switch and `clearMessages`.
+- `src/pages/DmChat/DmChat.tsx`
+  - Renders composer-level reply preview above input.
+  - Sends `replyToMessageId` in `messageActions.sendMessage` payload.
+  - Clears reply target after send and on explicit cancel.
+- `src/components/DmItemsList/DmItemsList.tsx`
+  - Adds `Reply` context-menu action.
+  - Renders per-message reply block from `replyPreview`/`replyToMessageId`.
+  - Handles click-to-jump to parent message (if loaded) and temporary highlight.
+  - Shows fallback notice if parent message is not currently loaded.
+- `src/components/DmItemsList/DmItemsList.module.css`
+  - Styles for inline reply block, jump highlight, and missing-parent notice.
+- `src/pages/DmChat/DmChat.module.css`
+  - Styles for composer reply preview and cancel action.
+
+## Reply target state
+- Location: `message` slice in Redux.
+- Shape is intentionally minimal and predictable:
+  - `messageId`
+  - `authorDisplayName`
+  - `snippet`
+  - `deleted`
+- Not storing full message object avoids stale/duplicated state.
+
+## Data flow (fetch/ws -> render)
+- Backend already includes `replyToMessageId` and `replyPreview` in `ShortMessage` payload.
+- Existing fetch (`fetchRoomMessages`) and websocket reducer (`execEventMessage`) already keep these fields in `messages` as part of full message objects.
+- UI rendering uses only message DTO fields:
+  - composer uses slice `replyTarget` (local user selection)
+  - message bubble uses `message.replyPreview` and `message.replyToMessageId`
+- No websocket middleware changes are required for reply metadata transport.
+
+## Jump to original message
+- Reply block click checks current `messageRefs` map (`messageId -> element`).
+- If parent exists in loaded list:
+  - smooth scroll to parent (`block: center`)
+  - set temporary `highlightedMessageId`
+  - auto-clear highlight via timeout
+- If parent is missing from loaded list:
+  - no hard failure
+  - show short fallback notice in message list
+- No heavy backfill loading is triggered to avoid pagination/scroll regressions.
+
+## Known limitations
+- Jump works only for messages currently loaded in memory.
+- No threaded/nested replies (single-level UX only, by design).
+- Reply action is available in context menu; no separate hover icon was added.
+- Missing/deleted parent shows fallback text; no attempt to reconstruct full parent message.
+
+## Safe vs risky changes
+- Safe:
+  - tweaking reply preview text/styles
+  - updating fallback wording
+  - adjusting highlight timeout/duration
+- Risky:
+  - changing `message/sendMessage` payload contract (`replyToMessageId` name/type)
+  - altering room-switch resets in `message.slice.ts`
+  - modifying scroll/pagination behavior in `DmItemsList` without regression checks
+
+## Manual QA checklist
+1. Reply to own message.
+2. Reply to another user's message.
+3. Reply to a message that itself is a reply.
+4. Cancel reply in composer.
+5. Send with Enter while reply is active.
+6. Verify outgoing payload includes `replyToMessageId` (or `null` when no reply).
+7. Verify reply block renders in sent/received messages.
+8. Click reply block when parent is loaded -> scroll + temporary highlight.
+9. Click reply block when parent not loaded -> fallback notice, no crash.
+10. Switch room while reply is active -> reply preview resets.
+11. Confirm edit/delete/read-marker/new-divider/day-divider behavior still works.
+12. Verify upward pagination still restores scroll position.
+
+## Open questions / assumptions
+- Assumption: backend continues to provide `replyPreview` for parent-unavailable cases.
+- Assumption: deleted parents are represented via `replyPreview.deleted` and/or missing parent in list.
+- Open question: should reply action also be exposed for touch/mobile UI beyond context menu.

--- a/src/components/DmItemsList/DmItemsList.module.css
+++ b/src/components/DmItemsList/DmItemsList.module.css
@@ -49,6 +49,10 @@
 	background: var(--bg-hover);
 }
 
+.message-row-highlighted {
+	background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
 .msg-avatar {
 	width: 40px;
 	height: 40px;
@@ -106,6 +110,46 @@
 	overflow-wrap: break-word;
 	word-break: break-word;
 	line-height: 20px;
+}
+
+.reply-block {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 2px;
+	padding: 6px 8px;
+	border-left: 3px solid var(--accent);
+	border-radius: 8px;
+	background: var(--bg-secondary);
+	cursor: pointer;
+	border-top: none;
+	border-right: none;
+	border-bottom: none;
+	text-align: left;
+	max-width: 100%;
+}
+
+.reply-block:hover {
+	background: var(--bg-hover);
+}
+
+.reply-author {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--accent);
+	max-width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.reply-content {
+	font-size: 12px;
+	color: var(--text-secondary);
+	max-width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .read-status {
@@ -237,6 +281,18 @@
 
 .menu-animate {
 	animation: menuIn 0.12s ease;
+}
+
+.reply-jump-notice {
+	position: sticky;
+	bottom: 10px;
+	margin-left: auto;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border);
+	color: var(--text-secondary);
+	font-size: 12px;
+	padding: 8px 10px;
+	border-radius: 8px;
 }
 
 .my-message {

--- a/src/components/DmItemsList/DmItemsList.tsx
+++ b/src/components/DmItemsList/DmItemsList.tsx
@@ -26,6 +26,8 @@ export function DmItemsList() {
 	const [editingMsgId, setEditingMsgId] = useState<number | null>(null);
 	const [editContent, setEditContent] = useState("");
 	const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+	const [highlightedMessageId, setHighlightedMessageId] = useState<number | null>(null);
+	const [replyJumpNotice, setReplyJumpNotice] = useState<string | null>(null);
 
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const messageRefs = useRef<Map<number, HTMLDivElement>>(new Map());
@@ -206,11 +208,50 @@ export function DmItemsList() {
 		setEditContent("");
 	}
 
+	const getReplySnippet = (msg: ShortMessage) => {
+		if (msg.replyPreview?.deleted) return "Original message was deleted";
+		const source = msg.replyPreview?.snippet || msg.content || "";
+		return source.replace(/\s+/g, " ").trim().slice(0, 120);
+	}
+
+	const handleStartReply = (msg: ShortMessage) => {
+		if (msg.eventType === "MESSAGE_DELETE") return;
+
+		dispatch(
+			messageActions.startReply({
+				messageId: msg.id,
+				authorDisplayName: msg.sender.displayName,
+				snippet: getReplySnippet(msg),
+				deleted: msg.replyPreview?.deleted ?? false
+			})
+		);
+	}
+
+	const handleReplyJump = (msg: ShortMessage) => {
+		if (!msg.replyToMessageId) return;
+
+		const targetEl = messageRefs.current.get(msg.replyToMessageId);
+		if (!targetEl) {
+			setReplyJumpNotice("Original message is not loaded in the current list");
+			window.setTimeout(() => setReplyJumpNotice(null), 2200);
+			return;
+		}
+
+		targetEl.scrollIntoView({
+			behavior: "smooth",
+			block: "center"
+		});
+		setHighlightedMessageId(msg.replyToMessageId);
+		window.setTimeout(() => {
+			setHighlightedMessageId(current => (current === msg.replyToMessageId ? null : current));
+		}, 1600);
+	}
+
 	const openContextMenu = (e: React.MouseEvent, msg: ShortMessage) => {
 		e.preventDefault();
 
 		const menuWidth = 160;
-		const menuHeight = 96;
+		const menuHeight = msg.sender.username === myUser?.username ? 132 : 48;
 
 		let x = e.clientX;
 		let y = e.clientY;
@@ -282,9 +323,12 @@ export function DmItemsList() {
 						}}
 						data-id={item.payload.id}
 						data-sender={item.payload.sender.username}
-						className={styles["message-row"]}
+						className={cn(
+							styles["message-row"],
+							highlightedMessageId === item.payload.id && styles["message-row-highlighted"]
+						)}
 						onContextMenu={(e) => {
-							isMyMessage && openContextMenu(e, item.payload)
+							openContextMenu(e, item.payload)
 						}}>
 						<div className={styles["msg-avatar"]} style={{background: StringToColor(item.payload.sender.username)}}>
 							{item.payload.sender.avatarUrl ? (
@@ -327,10 +371,28 @@ export function DmItemsList() {
 									</div>
 								</div>
 							) : (
+								<>
+									{item.payload.replyToMessageId !== null && (
+										<button
+											className={styles["reply-block"]}
+											onClick={() => handleReplyJump(item.payload)}
+											type="button"
+										>
+											<span className={styles["reply-author"]}>
+												{item.payload.replyPreview?.authorDisplayName || "Unknown user"}
+											</span>
+											<span className={styles["reply-content"]}>
+												{item.payload.replyPreview?.deleted
+													? "Original message was deleted"
+													: item.payload.replyPreview?.snippet || "Original message unavailable"}
+											</span>
+										</button>
+									)}
 
-								<div className={styles["msg-text"]}>
-									{item.payload.content}
-								</div>
+									<div className={styles["msg-text"]}>
+										{item.payload.content}
+									</div>
+								</>
 							)}
 
 						</div>
@@ -338,12 +400,28 @@ export function DmItemsList() {
 				)
 			})}
 
+			{replyJumpNotice && (
+				<div className={styles["reply-jump-notice"]}>{replyJumpNotice}</div>
+			)}
+
 			{contextMenu && (
 				<div
 					className={cn(styles["context-menu"], styles["menu-animate"])}
 					style={{ top: contextMenu.y, left: contextMenu.x }}
 					onClick={(e) => e.stopPropagation()}
 				>
+					<button
+						onClick={() => {
+							const msg = messages.find(m => m.id === contextMenu.messageId);
+							if (msg) handleStartReply(msg);
+							setContextMenu(null);
+						}}>
+						Reply
+					</button>
+
+					{messages.find(m => m.id === contextMenu.messageId)?.sender.username === myUser?.username && (
+						<>
+							<div className={styles["menu-divider"]} />
 					<button
 						onClick={() => {
 							const msg = messages.find(m => m.id === contextMenu.messageId);
@@ -364,6 +442,8 @@ export function DmItemsList() {
 					>
 						Delete
 					</button>
+						</>
+					)}
 				</div>
 			)}
 		</div>

--- a/src/pages/DmChat/DmChat.module.css
+++ b/src/pages/DmChat/DmChat.module.css
@@ -54,10 +54,66 @@
 
 .input-bar {
 	display: flex;
-	align-items: center;
+	flex-direction: column;
+	align-items: stretch;
 	padding: 12px 16px 16px;
-	gap: 8px;
+	gap: 10px;
 	flex-shrink: 0;
+}
+
+.reply-preview {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 10px;
+	padding: 8px 10px;
+	border-left: 3px solid var(--accent);
+	border-radius: 8px;
+	background: var(--bg-secondary);
+}
+
+.reply-preview-content {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.reply-label {
+	color: var(--accent);
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.reply-snippet {
+	color: var(--text-secondary);
+	font-size: 12px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 100%;
+}
+
+.reply-cancel {
+	background: transparent;
+	border: none;
+	outline: none;
+	cursor: pointer;
+	color: var(--text-secondary);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-top: 1px;
+}
+
+.reply-cancel:hover {
+	color: var(--text-primary);
+}
+
+.composer-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .input {

--- a/src/pages/DmChat/DmChat.tsx
+++ b/src/pages/DmChat/DmChat.tsx
@@ -8,7 +8,7 @@ import { DmItemsList } from "../../components/DmItemsList/DmItemsList";
 import { fetchMyRooms } from "../../store/slices/room.slice";
 import { callActions } from "../../store/slices/call.slice";
 import type { Room } from "../../entities/room";
-import { Phone, Send, SettingsIcon } from "lucide-react";
+import { Phone, Send, SettingsIcon, X } from "lucide-react";
 import { RoomSettingModal } from "../../components/RoomSettingModal/RoomSettingModal";
 import { StringToColor } from "../../utils/stringHelpers";
 
@@ -19,6 +19,7 @@ export function DmChat() {
 
 	const { rooms } = useSelector((s: RootState) => s.room);
 	const { myUser } = useSelector((s: RootState) => s.user);
+	const { replyTarget } = useSelector((s: RootState) => s.message);
 
 	const [text, setText] = useState("");
 	const [isRoomSettingOpen, setIsRoomSettingOpen] = useState<boolean>(false);
@@ -103,12 +104,13 @@ export function DmChat() {
 				roomId: roomId,
 				content: {
 					content: text.trim(),
-					replyToMessageId: null
+					replyToMessageId: replyTarget?.messageId ?? null
 				}
 			})
 		);
 
 		setText("");
+		dispatch(messageActions.cancelReply());
 	};
 
 	const handleKeyPress = (e: React.KeyboardEvent) => {
@@ -186,16 +188,39 @@ export function DmChat() {
 			<DmItemsList />
 
 			<div className={styles["input-bar"]}>
-				<input
-					className={styles["input"]}
-					placeholder="Message @here"
-					value={text}
-					onChange={(e) => setText(e.target.value)}
-					onKeyDown={handleKeyPress}
-				/>
-				<button className={styles["message-button"]} onClick={onSend}>
-					<Send color="white" size={20} />
-				</button>
+				{replyTarget && (
+					<div className={styles["reply-preview"]}>
+						<div className={styles["reply-preview-content"]}>
+							<span className={styles["reply-label"]}>
+								Replying to {replyTarget.authorDisplayName}
+							</span>
+							<span className={styles["reply-snippet"]}>
+								{replyTarget.deleted
+									? "Original message was deleted"
+									: replyTarget.snippet || "Message unavailable"}
+							</span>
+						</div>
+						<button
+							className={styles["reply-cancel"]}
+							onClick={() => dispatch(messageActions.cancelReply())}
+							aria-label="Cancel reply"
+						>
+							<X size={14} />
+						</button>
+					</div>
+				)}
+				<div className={styles["composer-row"]}>
+					<input
+						className={styles["input"]}
+						placeholder="Message @here"
+						value={text}
+						onChange={(e) => setText(e.target.value)}
+						onKeyDown={handleKeyPress}
+					/>
+					<button className={styles["message-button"]} onClick={onSend}>
+						<Send color="white" size={20} />
+					</button>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/store/interfaces/actions.interface.ts
+++ b/src/store/interfaces/actions.interface.ts
@@ -8,7 +8,7 @@ interface SendMessageAction {
 	payload: {
 		roomId: string, content: {
 			content: string,
-			replyToMessage: number | null
+			replyToMessageId: number | null
 		}
 	};
 }

--- a/src/store/slices/message.slice.ts
+++ b/src/store/slices/message.slice.ts
@@ -14,6 +14,12 @@ export interface MessageState {
 	activeRoomId: number | null;
 	isAtBottom: boolean;
 	newDividerMessageId: number | null;
+	replyTarget: {
+		messageId: number;
+		authorDisplayName: string;
+		snippet: string;
+		deleted: boolean;
+	} | null;
 }
 
 const initialState: MessageState = {
@@ -24,7 +30,8 @@ const initialState: MessageState = {
 	oldestMessageId: null,
 	activeRoomId: null,
 	isAtBottom: false,
-	newDividerMessageId: null
+	newDividerMessageId: null,
+	replyTarget: null
 };
 
 export const fetchRoomMessages = createAsyncThunk(
@@ -103,9 +110,20 @@ export const messageSlice = createSlice({
 			roomId: string | number;
 			content: {
 				content: string
-				replyToMessageId: null
+				replyToMessageId: number | null
 			}
 		}>) => { },
+		startReply: (currentState, action: PayloadAction<{
+			messageId: number;
+			authorDisplayName: string;
+			snippet: string;
+			deleted: boolean;
+		}>) => {
+			currentState.replyTarget = action.payload;
+		},
+		cancelReply: (currentState) => {
+			currentState.replyTarget = null;
+		},
 		sendPrivateMessage: (currentState, action: PayloadAction<{
 			receiver: string,
 			content: string
@@ -138,9 +156,11 @@ export const messageSlice = createSlice({
 			currentState.oldestMessageId = null;
 			currentState.hasMore = true;
 			currentState.status = "idle";
+			currentState.replyTarget = null;
 		},
 		setActiveRoom: (currentState, action: PayloadAction<number | null>) => {
 			currentState.activeRoomId = action.payload;
+			currentState.replyTarget = null;
 			if (action.payload === null) {
 				currentState.newDividerMessageId = null;
 			}


### PR DESCRIPTION
### Motivation
- Provide a minimal, single-level reply UX for DM/room chat using existing backend support (`replyToMessageId` + `replyPreview`) without changing transport or message contracts.
- Keep reply state predictable and local to message domain while preserving existing pagination, websocket, edit/delete and read flows.

### Description
- Added minimal `replyTarget` to `message.slice` with `startReply` and `cancelReply` actions and automatic reset on room switch and `clearMessages` to avoid stale state.
- Updated DM composer in `DmChat` to render a compact reply preview above the input, allow cancelling, and include `replyToMessageId` in the `sendMessage` payload; reply state is cleared after send.
- Extended `DmItemsList` to expose a `Reply` action in the context menu, render a compact inline reply block using `replyPreview`, and implement click-to-jump behaviour that scrolls to a loaded parent message and applies a transient highlight with a graceful fallback when the parent is not loaded.
- Added CSS rules for composer reply preview, reply block, jump highlight and fallback notice, adjusted context-menu height when extra items are shown, fixed action payload type name in `actions.interface.ts`, and added `docs/message-replies-frontend-notes.md` documenting the design and integration points.

### Testing
- Ran `npm run lint` which failed due to repository baseline issue: missing ESLint flat config (`eslint.config.*`) unrelated to these changes; no lint regressions introduced by this PR were checked because of the baseline failure.
- Ran `npm run build` which failed due to existing TypeScript errors in unrelated files across the repo (pre-existing baseline errors such as unused declarations and type issues); the reply UI changes compile locally within modified files but full project build could not complete due to those baseline errors.
- No automated unit/integration tests exist in the repo; manual QA checklist and usage notes are provided in `docs/message-replies-frontend-notes.md` for verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69ebc9cac832e806b658602f8e878)