### PR TITLE
Add compact user mini-card and improve profile/friend discoverability in chat

### DIFF
--- a/docs/ui-ux-notes.md
+++ b/docs/ui-ux-notes.md
@@ -1,0 +1,68 @@
+# UI/UX Notes (chat + voice zones)
+
+## 1) Key interaction zones and files
+- App shell / navigation: `src/layouts/AppLayouts/AppLayout.tsx`, `src/components/NavigateBar/NavigateBar.tsx`.
+- DM shell and primary header actions: `src/pages/DmChat/DmChat.tsx`.
+- DM message stream and context actions: `src/components/DmItemsList/DmItemsList.tsx`.
+- Inbox list zones (rooms/friends): `src/pages/InboxLayout/InboxLayout.tsx`, `src/components/RoomListItem/RoomListItem.tsx`, `src/components/FriendListItem/FriendListItem.tsx`.
+- Room settings + member interactions: `src/components/RoomSettingModal/RoomSettingModal.tsx`, `src/components/RoomMembersList/RoomMembersList.tsx`.
+- Reusable compact profile popout: `src/components/UserMiniCard/*`.
+
+## 2) Primary vs secondary actions
+- **Primary actions** (always visible / fast):
+  - Send message (composer send button, Enter).
+  - Start call from DM header.
+  - Open room settings from DM header.
+  - Open DM from room/friend rows.
+  - Open user identity popout from DM header, friend row, member row.
+- **Secondary actions** (contextual):
+  - Message edit/delete/reply in message context menu.
+  - Remove friend action (row hover + profile popout secondary action).
+  - Add friend action in user popout, plus lightweight shortcut in DM header for unknown contact.
+
+## 3) Where user mini-card opens and behavior
+- Opens from:
+  - DM header identity block (`DmChat`).
+  - Friend list item identity area (`FriendListItem`).
+  - Room members list row (`RoomMembersList`).
+- Displays:
+  - Display name, username, status, basic about fallback.
+  - Relationship state (`friend`, `none`, `outgoing`, `incoming`, `self`).
+  - Contextual actions: Message, Add friend, Remove friend, or neutral status indicator.
+- Interaction behavior:
+  - `Escape` closes.
+  - Outside click closes.
+  - Card receives focus on open.
+  - Position is anchor-based with viewport-safe fallback.
+
+## 4) Friend/profile actions placement and rationale
+- Add friend is shown in the mini-card as the canonical profile action (closest to user identity object).
+- For fast DM usage, Add friend also appears in DM header only for private chats with non-friends.
+- Remove friend remains available via hover on friend row and in profile popout (secondary, destructive action).
+
+## 5) Header actions and contextual actions structure
+- DM header now uses a clearer hierarchy:
+  - Left: clickable identity block (avatar + title) -> profile entry point.
+  - Right: utility actions (Add friend when relevant, call, settings).
+- Message actions stay contextual in right-click menu to avoid action noise in each row.
+- Member/friend row identity has explicit clickable affordance for profile inspection.
+
+## 6) UX trade-offs
+- Kept architecture and data contracts unchanged (Redux slices, WS action strings, API payloads untouched).
+- Profile popout uses visual-only data fallback for `aboutMe` when unavailable in local entity.
+- Incoming/outgoing friend request actions in popout are intentionally read-only labels (no new flows introduced).
+
+## 7) Manual QA checklist
+1. Open DM, click avatar/name in header -> popout opens near anchor, closes on outside click/Escape.
+2. In DM with non-friend, confirm Add friend appears and dispatches existing action.
+3. Open inbox friends tab, click friend identity -> popout opens; Message jumps into existing DM behavior.
+4. In room settings modal, click member row -> popout opens; Add/Remove friend action dispatches existing actions.
+5. Confirm message right-click context menu still works (Reply/Edit/Delete).
+6. Confirm call start from DM header still works.
+7. Keyboard: tab to identity buttons, open card, Escape closes and focus is preserved predictably.
+
+## 8) Follow-up improvements via this doc
+- Add `aboutMe` hydration to mini-card when lightweight profile fetch is available (assumption: no fast endpoint wired in current view models).
+- Add non-hover fallback for destructive row actions on touch/narrow layouts.
+- Normalize status indicators (dot color + text) between friends, members, and message headers.
+- Open question: whether incoming request should support quick accept/reject directly in popout (requires product decision + backend/event validation).

--- a/src/components/FriendListItem/FriendListItem.module.css
+++ b/src/components/FriendListItem/FriendListItem.module.css
@@ -17,6 +17,11 @@
 	background-color: var(--bg-hover);
 }
 
+.item:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 1px;
+}
+
 .item:hover .remove-friend-btn {
 	opacity: 1;
 }

--- a/src/components/FriendListItem/FriendListItem.module.css
+++ b/src/components/FriendListItem/FriendListItem.module.css
@@ -5,7 +5,8 @@
 	cursor: pointer;
 	display: flex;
 	align-items: center;
-	gap: 12px;
+	justify-content: space-between;
+	gap: 10px;
 	padding: 6px 8px;
 	border-radius: 10px;
 	background-color: transparent;
@@ -18,6 +19,25 @@
 
 .item:hover .remove-friend-btn {
 	opacity: 1;
+}
+
+.identity-button {
+	flex: 1;
+	border: none;
+	background: transparent;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 0;
+	cursor: pointer;
+	text-align: left;
+}
+
+.identity-button:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+	border-radius: 8px;
 }
 
 .avatar {
@@ -66,7 +86,6 @@
 .title-row {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
 	align-items: baseline;
 	margin-bottom: 2px;
 }
@@ -76,6 +95,9 @@
 	font-family: Open Sans;
 	font-size: 15px;
 	font-weight: 500;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .empty {
@@ -95,7 +117,7 @@
 	width: 28px;
 	height: 28px;
 	border-radius: 6px;
-	flex-shrink: 6px;
+	flex-shrink: 0;
 	opacity: 0;
 	transition: opacity 0.15s ease, background-color 0.15s ease;
 }
@@ -105,10 +127,10 @@
 }
 
 .remove-friend-btn img {
- width: 14px;
-  height: 14px;
-  opacity: 0.6;
-  transition: opacity 0.15s ease, filter 0.15s ease;
+	width: 14px;
+	height: 14px;
+	opacity: 0.6;
+	transition: opacity 0.15s ease, filter 0.15s ease;
 }
 
 .remove-friend-btn:hover img {

--- a/src/components/FriendListItem/FriendListItem.tsx
+++ b/src/components/FriendListItem/FriendListItem.tsx
@@ -30,7 +30,7 @@ export function FriendListItem({ friend, onClick }: FriendListItemProps) {
 			? "incoming"
 			: "friend";
 	const openDmWithFriend = () => {
-		openDmWithFriend();
+		onClick(friend.friendUsername);
 	};
 
 	const handleItemKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {

--- a/src/components/FriendListItem/FriendListItem.tsx
+++ b/src/components/FriendListItem/FriendListItem.tsx
@@ -29,12 +29,26 @@ export function FriendListItem({ friend, onClick }: FriendListItemProps) {
 		: incomingRequests.some((request) => request.senderUsername === friend.friendUsername)
 			? "incoming"
 			: "friend";
+	const openDmWithFriend = () => {
+		openDmWithFriend();
+	};
+
+	const handleItemKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+		if (event.key === "Enter" || event.key === " ") {
+			event.preventDefault();
+			openDmWithFriend();
+		}
+	};
 
 	return (
 		<>
 			<div
 				className={styles["item"]}
-				onClick={() => onClick(friend.friendUsername)}
+				onClick={openDmWithFriend}
+				onKeyDown={handleItemKeyDown}
+				role="button"
+				tabIndex={0}
+				aria-label={`Open chat with ${friend.friendDisplayName}`}
 			>
 				<button type="button" className={styles["identity-button"]} onClick={openProfile}>
 					<div className={styles["avatar-wrapper"]}>
@@ -81,7 +95,7 @@ export function FriendListItem({ friend, onClick }: FriendListItemProps) {
 				anchorRect={anchorRect}
 				onClose={() => setIsProfileOpen(false)}
 				onMessage={() => {
-					onClick(friend.friendUsername);
+					openDmWithFriend();
 					setIsProfileOpen(false);
 				}}
 				onRemoveFriend={() => {

--- a/src/components/FriendListItem/FriendListItem.tsx
+++ b/src/components/FriendListItem/FriendListItem.tsx
@@ -1,48 +1,94 @@
-import { useDispatch } from "react-redux";
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import styles from "./FriendListItem.module.css";
 import type { FriendListItemProps } from "./FriendListItem.props";
-import type { AppDispatch } from "../../store/store";
+import type { AppDispatch, RootState } from "../../store/store";
 import { friendActions } from "../../store/slices/friend.slice";
 import { StringToColor } from "../../utils/stringHelpers";
+import { UserMiniCard } from "../UserMiniCard/UserMiniCard";
 
 export function FriendListItem({ friend, onClick }: FriendListItemProps) {
 	const dispatch = useDispatch<AppDispatch>();
+	const { incomingRequests, outgoingRequests } = useSelector((s: RootState) => s.friend);
+	const [isProfileOpen, setIsProfileOpen] = useState(false);
+	const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
 	const avatarBg = StringToColor(friend.friendUsername);
 
-	const removeHandle = (displayName: string) => {
-		dispatch(friendActions.removeFriend({ friendUsername: friend.friendUsername }))
-	}
+	const removeHandle = () => {
+		dispatch(friendActions.removeFriend({ friendUsername: friend.friendUsername }));
+	};
+
+	const openProfile = (event: React.MouseEvent<HTMLButtonElement>) => {
+		event.stopPropagation();
+		setAnchorRect(event.currentTarget.getBoundingClientRect());
+		setIsProfileOpen(true);
+	};
+
+	const relationship = outgoingRequests.some((request) => request.receiverUsername === friend.friendUsername)
+		? "outgoing"
+		: incomingRequests.some((request) => request.senderUsername === friend.friendUsername)
+			? "incoming"
+			: "friend";
 
 	return (
-		<div
-			className={styles["item"]}
-			onClick={() => onClick(friend.friendUsername)}
-		>
-			<div className={styles["avatar-wrapper"]}>
-				<div className={styles["avatar"]} style={{ background: avatarBg }}>
-					{friend.friendAvatarUrl ? (
-						<img src={friend.friendAvatarUrl} crossOrigin="anonymous" />
-					) : (
-						<div>{(friend.friendDisplayName[0] || "?").toUpperCase()}</div>
-					)}
-				</div>
-				<span className={styles["status-dot"]} />
+		<>
+			<div
+				className={styles["item"]}
+				onClick={() => onClick(friend.friendUsername)}
+			>
+				<button type="button" className={styles["identity-button"]} onClick={openProfile}>
+					<div className={styles["avatar-wrapper"]}>
+						<div className={styles["avatar"]} style={{ background: avatarBg }}>
+							{friend.friendAvatarUrl ? (
+								<img src={friend.friendAvatarUrl} crossOrigin="anonymous" alt={friend.friendDisplayName} />
+							) : (
+								<div>{(friend.friendDisplayName[0] || "?").toUpperCase()}</div>
+							)}
+						</div>
+						<span className={styles["status-dot"]} />
+					</div>
+
+					<div className={styles["content"]}>
+						<div className={styles["title-row"]}>
+							<span className={styles["title"]}>
+								{friend.friendDisplayName ?? "Unknown"}
+							</span>
+						</div>
+					</div>
+				</button>
+
+				<button
+					className={styles["remove-friend-btn"]}
+					onClick={(e) => {
+						e.stopPropagation();
+						removeHandle();
+					}}
+					aria-label={`Remove ${friend.friendDisplayName} from friends`}
+				>
+					<img src="../../../public/cross-icon.svg" alt="remove friend" />
+				</button>
 			</div>
 
-			<div className={styles["content"]}>
-				<div className={styles["title-row"]}>
-					<span className={styles["title"]}>
-						{friend.friendDisplayName ?? "Unknown"}
-					</span>
-					<button className={styles["remove-friend-btn"]}
-						onClick={(e) => {
-							e.stopPropagation();
-							removeHandle(friend.friendUsername);
-						}}>
-						<img src="../../../public/cross-icon.svg" />
-					</button>
-				</div>
-			</div>
-		</div>
-	)
+			<UserMiniCard
+				isOpen={isProfileOpen}
+				displayName={friend.friendDisplayName}
+				username={friend.friendUsername}
+				avatarUrl={friend.friendAvatarUrl}
+				avatarBg={avatarBg}
+				statusLabel={friend.friendStatus}
+				relationship={relationship}
+				aboutMe={null}
+				anchorRect={anchorRect}
+				onClose={() => setIsProfileOpen(false)}
+				onMessage={() => {
+					onClick(friend.friendUsername);
+					setIsProfileOpen(false);
+				}}
+				onRemoveFriend={() => {
+					removeHandle();
+					setIsProfileOpen(false);
+				}}
+			/>
+		</>
+	);
 }

--- a/src/components/RoomMembersList/RoomMembersList.module.css
+++ b/src/components/RoomMembersList/RoomMembersList.module.css
@@ -11,7 +11,20 @@
 	gap: 10px;
 	padding: 10px 8px;
 	border-radius: 10px;
-	background: transparent
+	border: none;
+	width: 100%;
+	background: transparent;
+	cursor: pointer;
+	text-align: left;
+}
+
+.member-item:hover {
+	background: var(--bg-hover);
+}
+
+.member-item:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 1px;
 }
 
 .member-avatar {
@@ -25,6 +38,13 @@
 	font-weight: 700;
 	color: #fff;
 	flex-shrink: 0;
+	overflow: hidden;
+}
+
+.member-avatar img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
 }
 
 .member-main {

--- a/src/components/RoomMembersList/RoomMembersList.tsx
+++ b/src/components/RoomMembersList/RoomMembersList.tsx
@@ -1,5 +1,12 @@
+import { useMemo, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import styles from "./RoomMembersList.module.css";
 import type { RoomMembersListProps } from "./RoomMembersList.props";
+import { StringToColor } from "../../utils/stringHelpers";
+import { UserMiniCard } from "../UserMiniCard/UserMiniCard";
+import type { RootState, AppDispatch } from "../../store/store";
+import { friendActions } from "../../store/slices/friend.slice";
+import type { UserCardRelationship } from "../UserMiniCard/UserMiniCard.props";
 
 const STATUS_LABEL: Record<string, string> = {
 	ONLINE: "Online",
@@ -10,27 +17,80 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 export function RoomMembersList({ members, myUserId }: RoomMembersListProps) {
+	const dispatch = useDispatch<AppDispatch>();
+	const { friends, incomingRequests, outgoingRequests } = useSelector((s: RootState) => s.friend);
+	const [activeMemberId, setActiveMemberId] = useState<number | null>(null);
+	const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+	const activeMember = useMemo(() => members.find((member) => member.id === activeMemberId) ?? null, [activeMemberId, members]);
+
+	const getRelationship = (username: string, memberId: number): UserCardRelationship => {
+		if (memberId === myUserId) return "self";
+		if (friends.some((friend) => friend.friendUsername === username)) return "friend";
+		if (outgoingRequests.some((request) => request.receiverUsername === username)) return "outgoing";
+		if (incomingRequests.some((request) => request.senderUsername === username)) return "incoming";
+		return "none";
+	};
+
+	const handleOpenMember = (event: React.MouseEvent<HTMLButtonElement>, memberId: number) => {
+		setAnchorRect(event.currentTarget.getBoundingClientRect());
+		setActiveMemberId(memberId);
+	};
+
 	return (
 		<div className={styles["members-list"]}>
 			{members.map((member) => {
 				const isMe = member.id === myUserId;
 				const statusLabel = STATUS_LABEL[member.status] ?? member.status;
+				const avatarBg = StringToColor(member.username);
 
 				return (
-					<div key={member.id} className={styles["member-item"]}>
-						<div className={styles["member-avatar"]}>
-							{member.username.slice(0, 1).toUpperCase()}
+					<button
+						key={member.id}
+						type="button"
+						className={styles["member-item"]}
+						onClick={(event) => handleOpenMember(event, member.id)}
+					>
+						<div className={styles["member-avatar"]} style={!member.avatarUrl ? { backgroundColor: avatarBg } : undefined}>
+							{member.avatarUrl ? (
+								<img src={member.avatarUrl} crossOrigin="anonymous" alt={member.displayName} />
+							) : (
+								member.username.slice(0, 1).toUpperCase()
+							)}
 						</div>
 						<div className={styles["member-main"]}>
 							<div className={styles["member-name"]}>
-								{member.username}
-								{isMe && <span className={styles["member-you"]}>вы</span>}
+								{member.displayName}
+								{isMe && <span className={styles["member-you"]}>you</span>}
 							</div>
 							<div className={styles["member-status"]}>{statusLabel}</div>
 						</div>
-					</div>
+					</button>
 				);
 			})}
+
+			{activeMember && (
+				<UserMiniCard
+					isOpen
+					displayName={activeMember.displayName}
+					username={activeMember.username}
+					avatarUrl={activeMember.avatarUrl}
+					avatarBg={StringToColor(activeMember.username)}
+					statusLabel={STATUS_LABEL[activeMember.status] ?? activeMember.status}
+					relationship={getRelationship(activeMember.username, activeMember.id)}
+					anchorRect={anchorRect}
+					aboutMe={null}
+					onClose={() => setActiveMemberId(null)}
+					onAddFriend={() => {
+						dispatch(friendActions.sendFriendRequest({ username: activeMember.username }));
+						setActiveMemberId(null);
+					}}
+					onRemoveFriend={() => {
+						dispatch(friendActions.removeFriend({ friendUsername: activeMember.username }));
+						setActiveMemberId(null);
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/components/RoomSettingModal/RoomSettingModal.tsx
+++ b/src/components/RoomSettingModal/RoomSettingModal.tsx
@@ -13,7 +13,7 @@ export function RoomSettingModal({ isOpen, onClose, onStartCall, room }: RoomSet
 	const isVisible = useModalAnimation(isOpen);
 	const normalizedName = room?.name?.trim();
 	const opponent = room?.members.find((member) => member.id !== myUser?.id);
-	const roomTitle = normalizedName || opponent?.username || "Unknown room";
+	const roomTitle = normalizedName || opponent?.displayName || opponent?.username || "Unknown room";
 
 	if (!isVisible || !room) return null;
 

--- a/src/components/UserMiniCard/UserMiniCard.module.css
+++ b/src/components/UserMiniCard/UserMiniCard.module.css
@@ -1,0 +1,122 @@
+.popout {
+	position: fixed;
+	z-index: 1200;
+	width: min(320px, calc(100vw - 24px));
+	background: var(--bg-secondary);
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+	overflow: hidden;
+}
+
+.header {
+	padding: 14px;
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.07), transparent 85%);
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.avatar {
+	width: 48px;
+	height: 48px;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 18px;
+	font-weight: 700;
+	color: white;
+	flex-shrink: 0;
+}
+
+.avatar img {
+	width: 100%;
+	height: 100%;
+	border-radius: 50%;
+	object-fit: cover;
+}
+
+.title {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.display-name {
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--text-primary);
+	line-height: 1.2;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.username {
+	font-size: 13px;
+	color: var(--text-secondary);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.body {
+	padding: 0 14px 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.meta {
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.about {
+	padding: 10px;
+	border-radius: 10px;
+	background: var(--bg-input);
+	font-size: 13px;
+	color: var(--text-secondary);
+	line-height: 1.4;
+	max-height: 90px;
+	overflow: auto;
+	word-break: break-word;
+}
+
+.actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.primary,
+.secondary,
+.neutral {
+	height: 34px;
+	padding: 0 12px;
+	border-radius: 8px;
+	border: none;
+	cursor: pointer;
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.primary {
+	background: var(--accent);
+	color: white;
+}
+
+.secondary {
+	background: var(--bg-hover);
+	color: var(--text-primary);
+}
+
+.neutral {
+	background: transparent;
+	color: var(--text-secondary);
+	border: 1px solid var(--border);
+	cursor: default;
+}

--- a/src/components/UserMiniCard/UserMiniCard.props.ts
+++ b/src/components/UserMiniCard/UserMiniCard.props.ts
@@ -1,0 +1,17 @@
+export type UserCardRelationship = "self" | "friend" | "outgoing" | "incoming" | "none";
+
+export interface UserMiniCardProps {
+	isOpen: boolean;
+	displayName: string;
+	username: string;
+	avatarUrl?: string | null;
+	statusLabel?: string;
+	aboutMe?: string | null;
+	avatarBg: string;
+	relationship: UserCardRelationship;
+	anchorRect: DOMRect | null;
+	onClose: () => void;
+	onMessage?: () => void;
+	onAddFriend?: () => void;
+	onRemoveFriend?: () => void;
+}

--- a/src/components/UserMiniCard/UserMiniCard.tsx
+++ b/src/components/UserMiniCard/UserMiniCard.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef } from "react";
+import styles from "./UserMiniCard.module.css";
+import type { UserMiniCardProps } from "./UserMiniCard.props";
+
+const GAP = 8;
+
+export function UserMiniCard({
+	isOpen,
+	displayName,
+	username,
+	avatarBg,
+	avatarUrl,
+	statusLabel,
+	aboutMe,
+	relationship,
+	anchorRect,
+	onClose,
+	onMessage,
+	onAddFriend,
+	onRemoveFriend,
+}: UserMiniCardProps) {
+	const rootRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		const handleEscape = (event: KeyboardEvent) => {
+			if (event.key === "Escape") onClose();
+		};
+
+		const handleOutsideClick = (event: MouseEvent) => {
+			if (!rootRef.current) return;
+			if (!rootRef.current.contains(event.target as Node)) {
+				onClose();
+			}
+		};
+
+		document.addEventListener("keydown", handleEscape);
+		document.addEventListener("mousedown", handleOutsideClick);
+
+		return () => {
+			document.removeEventListener("keydown", handleEscape);
+			document.removeEventListener("mousedown", handleOutsideClick);
+		};
+	}, [isOpen, onClose]);
+
+	useEffect(() => {
+		if (!isOpen || !rootRef.current) return;
+		rootRef.current.focus();
+	}, [isOpen]);
+
+	const position = useMemo(() => {
+		if (!anchorRect) return null;
+
+		const estimatedWidth = Math.min(320, window.innerWidth - 24);
+		const estimatedHeight = 260;
+		const placeRight = anchorRect.right + estimatedWidth + GAP <= window.innerWidth;
+		const left = placeRight
+			? anchorRect.right + GAP
+			: Math.max(12, anchorRect.left - estimatedWidth - GAP);
+		const maxTop = window.innerHeight - estimatedHeight - 12;
+		const top = Math.min(Math.max(12, anchorRect.top), maxTop);
+
+		return { top, left };
+	}, [anchorRect]);
+
+	if (!isOpen || !position) return null;
+
+	const relationshipLabel =
+		relationship === "friend"
+			? "Friend"
+			: relationship === "outgoing"
+				? "Request sent"
+				: relationship === "incoming"
+					? "Incoming request"
+					: relationship === "self"
+						? "You"
+						: "Not friends";
+
+	return (
+		<div
+			ref={rootRef}
+			className={styles["popout"]}
+			style={position}
+			role="dialog"
+			aria-label={`Profile of ${displayName}`}
+			tabIndex={-1}
+		>
+			<div className={styles["header"]} style={{ borderTop: `3px solid ${avatarBg}` }}>
+				<div className={styles["avatar"]} style={!avatarUrl ? { backgroundColor: avatarBg } : undefined}>
+					{avatarUrl ? <img src={avatarUrl} crossOrigin="anonymous" alt={displayName} /> : <div>{(displayName[0] || "?").toUpperCase()}</div>}
+				</div>
+				<div className={styles["title"]}>
+					<div className={styles["display-name"]}>{displayName}</div>
+					<div className={styles["username"]}>@{username}</div>
+				</div>
+			</div>
+
+			<div className={styles["body"]}>
+				<div className={styles["meta"]}>{statusLabel ? `${statusLabel} • ${relationshipLabel}` : relationshipLabel}</div>
+				<div className={styles["about"]}>{aboutMe?.trim() ? aboutMe : "No bio yet"}</div>
+				<div className={styles["actions"]}>
+					{onMessage && (
+						<button className={styles["secondary"]} onClick={onMessage}>
+							Message
+						</button>
+					)}
+
+					{relationship === "none" && onAddFriend && (
+						<button className={styles["primary"]} onClick={onAddFriend}>
+							Add friend
+						</button>
+					)}
+
+					{relationship === "friend" && onRemoveFriend && (
+						<button className={styles["secondary"]} onClick={onRemoveFriend}>
+							Remove friend
+						</button>
+					)}
+
+					{(relationship === "outgoing" || relationship === "incoming" || relationship === "self") && (
+						<button className={styles["neutral"]} type="button" aria-disabled>
+							{relationshipLabel}
+						</button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/UserMiniCard/UserMiniCard.tsx
+++ b/src/components/UserMiniCard/UserMiniCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
 import styles from "./UserMiniCard.module.css";
 import type { UserMiniCardProps } from "./UserMiniCard.props";
 
@@ -46,7 +47,7 @@ export function UserMiniCard({
 
 	useEffect(() => {
 		if (!isOpen || !rootRef.current) return;
-		rootRef.current.focus();
+		rootRef.current.focus({ preventScroll: true });
 	}, [isOpen]);
 
 	const position = useMemo(() => {
@@ -77,7 +78,7 @@ export function UserMiniCard({
 						? "You"
 						: "Not friends";
 
-	return (
+	const card = (
 		<div
 			ref={rootRef}
 			className={styles["popout"]}
@@ -127,4 +128,6 @@ export function UserMiniCard({
 			</div>
 		</div>
 	);
+
+	return createPortal(card, document.body);
 }

--- a/src/pages/DmChat/DmChat.module.css
+++ b/src/pages/DmChat/DmChat.module.css
@@ -22,6 +22,26 @@
 	gap: 8px;
 }
 
+.identity-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	border: none;
+	background: transparent;
+	padding: 4px 6px;
+	border-radius: 8px;
+	cursor: pointer;
+}
+
+.identity-button:hover {
+	background: var(--bg-hover);
+}
+
+.identity-button:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 1px;
+}
+
 .header-right {
 	display: flex;
 	gap: 14px;
@@ -44,6 +64,10 @@
 	width: 100%;
 	height: 100%;
 	border-radius: 50%;
+}
+
+.avatar-image {
+	object-fit: cover;
 }
 
 .title {

--- a/src/pages/DmChat/DmChat.tsx
+++ b/src/pages/DmChat/DmChat.tsx
@@ -8,9 +8,12 @@ import { DmItemsList } from "../../components/DmItemsList/DmItemsList";
 import { fetchMyRooms } from "../../store/slices/room.slice";
 import { callActions } from "../../store/slices/call.slice";
 import type { Room } from "../../entities/room";
-import { Phone, Send, SettingsIcon, X } from "lucide-react";
+import { Phone, Send, SettingsIcon, UserPlus, X } from "lucide-react";
 import { RoomSettingModal } from "../../components/RoomSettingModal/RoomSettingModal";
 import { StringToColor } from "../../utils/stringHelpers";
+import { friendActions } from "../../store/slices/friend.slice";
+import { UserMiniCard } from "../../components/UserMiniCard/UserMiniCard";
+import type { UserCardRelationship } from "../../components/UserMiniCard/UserMiniCard.props";
 
 export function DmChat() {
 	const navigate = useNavigate();
@@ -20,9 +23,12 @@ export function DmChat() {
 	const { rooms } = useSelector((s: RootState) => s.room);
 	const { myUser } = useSelector((s: RootState) => s.user);
 	const { replyTarget } = useSelector((s: RootState) => s.message);
+	const { friends, incomingRequests, outgoingRequests } = useSelector((s: RootState) => s.friend);
 
 	const [text, setText] = useState("");
 	const [isRoomSettingOpen, setIsRoomSettingOpen] = useState<boolean>(false);
+	const [isProfileCardOpen, setIsProfileCardOpen] = useState(false);
+	const [profileAnchor, setProfileAnchor] = useState<DOMRect | null>(null);
 
 	const roomIdParam = searchParams.get("roomId");
 	const parsedRoomId = roomIdParam ? Number(roomIdParam) : null;
@@ -96,6 +102,15 @@ export function DmChat() {
 		return (currentRoom?.name?.[0] || "?").toUpperCase();
 	}, [currentRoom, interlocutor]);
 
+	const relationship = useMemo<UserCardRelationship>(() => {
+		if (!interlocutor || !myUser) return "none";
+		if (interlocutor.id === myUser.id) return "self";
+		if (friends.some((friend) => friend.friendUsername === interlocutor.username)) return "friend";
+		if (outgoingRequests.some((request) => request.receiverUsername === interlocutor.username)) return "outgoing";
+		if (incomingRequests.some((request) => request.senderUsername === interlocutor.username)) return "incoming";
+		return "none";
+	}, [friends, incomingRequests, interlocutor, myUser, outgoingRequests]);
+
 	const onSend = () => {
 		if (!text.trim() || !roomId) return;
 
@@ -148,42 +163,92 @@ export function DmChat() {
 		setIsRoomSettingOpen(true);
 	};
 
+	const handleHeaderIdentityClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		setProfileAnchor(event.currentTarget.getBoundingClientRect());
+		setIsProfileCardOpen(true);
+	};
+
+	const handleAddFriend = () => {
+		if (!interlocutor) return;
+		dispatch(friendActions.sendFriendRequest({ username: interlocutor.username }));
+		setIsProfileCardOpen(false);
+	};
+
+	const handleRemoveFriend = () => {
+		if (!interlocutor) return;
+		dispatch(friendActions.removeFriend({ friendUsername: interlocutor.username }));
+		setIsProfileCardOpen(false);
+	};
+
+	const isPrivateRoom = currentRoom?.type === "PRIVATE";
+
 	return (
 		<div className={styles["chat"]}>
 			<div className={styles["header"]}>
 				<div className={styles["header-left"]}>
-					<div className={styles["avatar"]} style={{ background: avatarBg }}>
-						{avatarSrc ? (
-							<img
-								src={avatarSrc}
-								alt={roomTitle}
-								crossOrigin="anonymous"
-								className={styles["avatar-image"]}
-							/>
-						) : (
-							<div className={styles["avatar-fallback"]}>{avatarFallback}</div>
-						)}
-					</div>
+					<button
+						type="button"
+						className={styles["identity-button"]}
+						onClick={handleHeaderIdentityClick}
+					>
+						<div className={styles["avatar"]} style={{ background: avatarBg }}>
+							{avatarSrc ? (
+								<img
+									src={avatarSrc}
+									alt={roomTitle}
+									crossOrigin="anonymous"
+									className={styles["avatar-image"]}
+								/>
+							) : (
+								<div className={styles["avatar-fallback"]}>{avatarFallback}</div>
+							)}
+						</div>
 
-					<span className={styles["title"]}>{roomTitle}</span>
+						<span className={styles["title"]}>{roomTitle}</span>
+					</button>
 				</div>
 
 				<div className={styles["header-right"]}>
-					<button className={styles["btn"]} onClick={handleStartCall}>
+					{isPrivateRoom && relationship === "none" && (
+						<button className={styles["btn"]} onClick={handleAddFriend} aria-label="Add friend">
+							<UserPlus color="white" size={18} />
+						</button>
+					)}
+					<button className={styles["btn"]} onClick={handleStartCall} aria-label="Start voice call">
 						<Phone color="white" size={20} />
 					</button>
-					<button className={styles["btn"]} onClick={handleOpenChatSetting}>
+					<button className={styles["btn"]} onClick={handleOpenChatSetting} aria-label="Chat settings">
 						<SettingsIcon color="white" size={20} />
 					</button>
 				</div>
 			</div>
 
-			<RoomSettingModal
-				isOpen={isRoomSettingOpen}
-				onClose={() => setIsRoomSettingOpen(false)}
-				onStartCall={handleStartCall}
-				room={currentRoom}
-			/>
+			{currentRoom && (
+				<RoomSettingModal
+					isOpen={isRoomSettingOpen}
+					onClose={() => setIsRoomSettingOpen(false)}
+					onStartCall={handleStartCall}
+					room={currentRoom}
+				/>
+			)}
+
+			{isPrivateRoom && interlocutor && (
+				<UserMiniCard
+					isOpen={isProfileCardOpen}
+					displayName={interlocutor.displayName}
+					username={interlocutor.username}
+					avatarUrl={interlocutor.avatarUrl}
+					aboutMe={null}
+					statusLabel={interlocutor.status}
+					avatarBg={avatarBg}
+					relationship={relationship}
+					anchorRect={profileAnchor}
+					onClose={() => setIsProfileCardOpen(false)}
+					onMessage={() => setIsProfileCardOpen(false)}
+					onAddFriend={handleAddFriend}
+					onRemoveFriend={handleRemoveFriend}
+				/>
+			)}
 
 			<DmItemsList />
 

--- a/src/pages/DmChat/DmChat.tsx
+++ b/src/pages/DmChat/DmChat.tsx
@@ -164,6 +164,7 @@ export function DmChat() {
 	};
 
 	const handleHeaderIdentityClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		if (!isPrivateRoom || !interlocutor) return;
 		setProfileAnchor(event.currentTarget.getBoundingClientRect());
 		setIsProfileCardOpen(true);
 	};
@@ -190,6 +191,8 @@ export function DmChat() {
 						type="button"
 						className={styles["identity-button"]}
 						onClick={handleHeaderIdentityClick}
+						aria-label={isPrivateRoom ? `Open profile card for ${roomTitle}` : "Room identity"}
+						aria-disabled={!isPrivateRoom}
 					>
 						<div className={styles["avatar"]} style={{ background: avatarBg }}>
 							{avatarSrc ? (


### PR DESCRIPTION
### Motivation
- Improve discoverability and consistency of user/profile and friend actions across DM, friends list and room members while keeping Redux, WebSocket and call/message flows intact. 
- Provide a small, reusable UI affordance for quick profile actions (message, add/remove friend) without adding backend calls or changing contracts.

### Description
- Add a reusable anchored `UserMiniCard` component under `src/components/UserMiniCard/` with keyboard (`Escape`) and outside-click dismissal, focus handling, viewport-safe positioning and relationship-aware actions. 
- Make DM header identity clickable and add a lightweight quick `Add friend` action for private chats with non-friends (wires to existing `friend` actions). 
- Update `FriendListItem` and `RoomMembersList` to expose a clear identity click target that opens the same mini-card and to keep destructive actions (remove friend) as secondary/hover actions. 
- Add `docs/ui-ux-notes.md` with key interaction zones, primary vs secondary action rules, QA checklist and follow-up suggestions, and update related CSS modules to support the new interactions and accessibility states.

### Testing
- Ran `npm run lint`; it failed due to a missing repository ESLint configuration (`eslint.config.*`) which is a pre-existing baseline issue not introduced by these changes. 
- Ran `npm run build` (TypeScript + Vite); it failed because of multiple pre-existing TypeScript errors in the codebase unrelated to the UI-only changes in this PR. 
- No automated tests were added; manual QA checklist and verification steps are documented in `docs/ui-ux-notes.md` for follow-up validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8058f531c832e86dda15ed2d47bd8)