### PR TITLE
Normalize room members via users slice and add USER_PROFILE_UPDATED WS handling

### DIFF
--- a/src/api/interfaces/RoomApiInterface.ts
+++ b/src/api/interfaces/RoomApiInterface.ts
@@ -1,13 +1,13 @@
 import type { AxiosResponse } from "axios";
-import type { Room } from "../../entities/room";
+import type { RoomApiResponse } from "../../entities/room";
 import type { GetRoomMessageParams } from "./GetRoomMessagesParams";
 import type { ShortMessage } from "../../entities/shortMessage";
 import type { CreateGroupBody } from "./CreateGroupBody";
 
 
 export interface RoomApiInterface {
-	myRooms: () => Promise<AxiosResponse<Room[]>>
+	myRooms: () => Promise<AxiosResponse<RoomApiResponse[]>>
 	getRoomMessage: (params: GetRoomMessageParams) => Promise<AxiosResponse<ShortMessage[]>>;
-	createGroup: (body: CreateGroupBody) => Promise<AxiosResponse<Room[]>>;
+	createGroup: (body: CreateGroupBody) => Promise<AxiosResponse<RoomApiResponse[]>>;
 	markRoomRead: (params: { roomId: number }) => Promise<AxiosResponse<void>>
 }

--- a/src/api/roomApi.ts
+++ b/src/api/roomApi.ts
@@ -1,4 +1,4 @@
-import type { Room } from "../entities/room";
+import type { RoomApiResponse } from "../entities/room";
 import { api } from "./api";
 import type { CreateGroupBody } from "./interfaces/CreateGroupBody";
 import type { GetRoomMessageParams } from "./interfaces/GetRoomMessagesParams";
@@ -7,13 +7,13 @@ import type { RoomApiInterface } from "./interfaces/RoomApiInterface";
 const ROOM_API_PREFIX = "/rooms"
 
 export const roomApi: RoomApiInterface = {
-	myRooms: () => api.get<Room[]>(`${ROOM_API_PREFIX}/all`),
+	myRooms: () => api.get<RoomApiResponse[]>(`${ROOM_API_PREFIX}/all`),
 	getRoomMessage: ({ beforeMessageId, limit = 15, roomId }: GetRoomMessageParams) => api.get(`${ROOM_API_PREFIX}/${roomId}/messages`, {
 		params: {
 			beforeMessageId,
 			limit
 		}
 	}),
-	createGroup: (body: CreateGroupBody) => api.post(`${ROOM_API_PREFIX}/createGroup`, body),
+	createGroup: (body: CreateGroupBody) => api.post<RoomApiResponse[]>(`${ROOM_API_PREFIX}/createGroup`, body),
 	markRoomRead: ({ roomId }) => api.post(`${ROOM_API_PREFIX}/${roomId}/read`)
 }

--- a/src/components/CallUi/CallUi.tsx
+++ b/src/components/CallUi/CallUi.tsx
@@ -38,6 +38,7 @@ export function CallUi({
 	const call = useSelector((s: RootState) => s.call);
 	const myUser = useSelector((s: RootState) => s.user.myUser);
 	const rooms = useSelector((s: RootState) => s.room.rooms);
+	const usersById = useSelector((s: RootState) => s.users.usersById);
 	const device = useSelector((s: RootState) => s.device);
 
 	const participants = useParticipants();
@@ -64,15 +65,18 @@ export function CallUi({
 
 	const participantAvatarResolver = useMemo(() => {
 		const avatarsByKey = new Map<string, string | null>();
-		const remoteMembers = currentRoom?.members.filter(
+		const roomMembers = currentRoom?.memberIds
+			.map((memberId) => usersById[memberId])
+			.filter((member) => member !== undefined) ?? [];
+		const remoteMembers = roomMembers.filter(
 			(member) => member.username !== myUser?.username
-		) ?? [];
+		);
 
 		if (myUser?.username) {
 			avatarsByKey.set(normalizeIdentityKey(myUser.username), myUser.avatarUrl ?? null);
 		}
 
-		currentRoom?.members.forEach((member) => {
+		roomMembers.forEach((member) => {
 			avatarsByKey.set(normalizeIdentityKey(member.username), member.avatarUrl ?? null);
 			avatarsByKey.set(String(member.id), member.avatarUrl ?? null);
 		});
@@ -99,7 +103,7 @@ export function CallUi({
 
 			return null;
 		};
-	}, [currentRoom, myUser?.avatarUrl, myUser?.username]);
+	}, [currentRoom, myUser?.avatarUrl, myUser?.username, usersById]);
 
 	const availableScreenTracks = useMemo(
 		() =>

--- a/src/components/RoomListItem/RoomListItem.tsx
+++ b/src/components/RoomListItem/RoomListItem.tsx
@@ -9,11 +9,12 @@ import { StringToColor } from "../../utils/stringHelpers";
 export function RoomListItem({ room }: RoomListItemProps) {
 	const navigate = useNavigate();
 	const myUser = useSelector((s: RootState) => s.user.myUser);
+	const usersById = useSelector((s: RootState) => s.users.usersById);
 
 	const isPrivateRoom = room.type === "PRIVATE";
 
 	const interlocutor = isPrivateRoom
-		? room.members?.find((member) => member.id !== myUser?.id) ?? null
+		? room.memberIds.map((memberId) => usersById[memberId]).find((member) => member?.id !== myUser?.id) ?? null
 		: null;
 
 	const title = isPrivateRoom
@@ -21,7 +22,7 @@ export function RoomListItem({ room }: RoomListItemProps) {
 		: room.name || "Unknown";
 
 	const avatarSrc = isPrivateRoom
-		? interlocutor?.avatarUrl || interlocutor?.avatartUrl || null
+		? interlocutor?.avatarUrl || null
 		: room.avatarUrl || null;
 
 	const avatarFallback = isPrivateRoom

--- a/src/components/RoomMembersList/RoomMembersList.props.ts
+++ b/src/components/RoomMembersList/RoomMembersList.props.ts
@@ -1,6 +1,6 @@
-﻿import type { RoomMembers } from "../../entities/roomMember";
+﻿import type { RoomMemberShort } from "../../entities/roomMember";
 
 export interface RoomMembersListProps {
-	members: RoomMembers[];
+	members: RoomMemberShort[];
 	myUserId?: number;
 }

--- a/src/components/RoomSettingModal/RoomSettingModal.tsx
+++ b/src/components/RoomSettingModal/RoomSettingModal.tsx
@@ -10,14 +10,16 @@ import { useNavigate } from "react-router-dom";
 export function RoomSettingModal({ isOpen, onClose, onStartCall, room }: RoomSettingModalProps) {
 	const navigate = useNavigate();
 	const myUser = useSelector((s: RootState) => s.user.myUser);
+	const usersById = useSelector((s: RootState) => s.users.usersById);
 	const isVisible = useModalAnimation(isOpen);
 	const normalizedName = room?.name?.trim();
-	const opponent = room?.members.find((member) => member.id !== myUser?.id);
+	const members = room?.memberIds.map((memberId) => usersById[memberId]).filter((member) => member !== undefined) ?? [];
+	const opponent = members.find((member) => member.id !== myUser?.id);
 	const roomTitle = normalizedName || opponent?.username || "Unknown room";
 
 	if (!isVisible || !room) return null;
 
-	const membersCount = room.members.length;
+	const membersCount = members.length;
 	const avatarLabel = room.type === "GROUP" ? "GR" : "DM";
 
 	return (
@@ -48,7 +50,7 @@ export function RoomSettingModal({ isOpen, onClose, onStartCall, room }: RoomSet
 
 				<div className={styles["room-info"]}>
 					<div className={styles["section-title"]}>Участники</div>
-					<RoomMembersList members={room.members} myUserId={myUser?.id} />
+					<RoomMembersList members={members} myUserId={myUser?.id} />
 				</div>
 			</div>
 		</div>

--- a/src/components/RoomsList/RoomsList.tsx
+++ b/src/components/RoomsList/RoomsList.tsx
@@ -8,6 +8,7 @@ import { formatTime } from "../../utils/timeHelpers";
 export function RoomsList({ rooms }: RoomsListProps) {
 	const navigate = useNavigate();
 	const { myUser } = useSelector((s: RootState) => s.user)
+	const usersById = useSelector((s: RootState) => s.users.usersById);
 
 	if (rooms.length === 0) {
 		return (
@@ -35,9 +36,9 @@ export function RoomsList({ rooms }: RoomsListProps) {
 					<div className={styles["content"]}>
 						<div className={styles["title-row"]}>
 							<span className={styles["title"]}>
-								{room.name ?? room.members?.find(member =>
-									member.id !== myUser?.id
-								)?.username ?? "Unknown"}
+								{room.name ?? room.memberIds
+									.map((memberId) => usersById[memberId])
+									.find((member) => member?.id !== myUser?.id)?.username ?? "Unknown"}
 							</span>
 							<div className={styles["right-side"]}>
 								{room.unreadCount > 0 && (

--- a/src/entities/room.ts
+++ b/src/entities/room.ts
@@ -1,8 +1,8 @@
-import type { RoomMembers } from "./roomMember";
+import type { RoomMemberShort } from "./roomMember";
 
 export type RoomType = "GROUP" | "PRIVATE";
 
-export interface Room {
+export interface RoomApiResponse {
 	id: number;
 	name: string;
 	type: RoomType;
@@ -14,5 +14,22 @@ export interface Room {
 	lastActivityAt: string | null;
 	unreadCount: number;
 	firstUnreadMessageId: number;
-	members: RoomMembers[]
+	members: RoomMemberShort[];
 }
+
+export interface RoomStateItem {
+	id: number;
+	name: string;
+	type: RoomType;
+	avatarUrl: string;
+	isActive: boolean;
+	createdAt: string;
+	lastMessageId: number | null;
+	lastMessageContent: string | null;
+	lastActivityAt: string | null;
+	unreadCount: number;
+	firstUnreadMessageId: number;
+	memberIds: number[];
+}
+
+export type Room = RoomStateItem;

--- a/src/entities/userShort.ts
+++ b/src/entities/userShort.ts
@@ -1,15 +1,13 @@
 import type { UserStatus } from "./interfaces/UserStatus";
 
-export interface RoomMemberShort {
+export interface UserShort {
 	id: number;
 	username: string;
 	displayName: string;
+	avatarUrl: string | null;
+	aboutMe?: string;
 	status: UserStatus;
 	lastSeenAt: string;
-	avatarUrl: string | null;
 	updatedAt: string;
 	createdAt: string;
-	aboutMe?: string;
 }
-
-export type RoomMembers = RoomMemberShort;

--- a/src/pages/DmChat/DmChat.tsx
+++ b/src/pages/DmChat/DmChat.tsx
@@ -7,7 +7,6 @@ import { fetchRoomMessages, messageActions } from "../../store/slices/message.sl
 import { DmItemsList } from "../../components/DmItemsList/DmItemsList";
 import { fetchMyRooms } from "../../store/slices/room.slice";
 import { callActions } from "../../store/slices/call.slice";
-import type { Room } from "../../entities/room";
 import { Phone, Send, SettingsIcon, X } from "lucide-react";
 import { RoomSettingModal } from "../../components/RoomSettingModal/RoomSettingModal";
 import { StringToColor } from "../../utils/stringHelpers";
@@ -19,6 +18,7 @@ export function DmChat() {
 
 	const { rooms } = useSelector((s: RootState) => s.room);
 	const { myUser } = useSelector((s: RootState) => s.user);
+	const usersById = useSelector((s: RootState) => s.users.usersById);
 	const { replyTarget } = useSelector((s: RootState) => s.message);
 
 	const [text, setText] = useState("");
@@ -48,18 +48,18 @@ export function DmChat() {
 
 	const currentRoom = useMemo(() => {
 		if (!roomId) return null;
-		return rooms?.find((room: Room) => room.id === roomId) ?? null;
+		return rooms?.find((room) => room.id === roomId) ?? null;
 	}, [rooms, roomId]);
 
 	const interlocutor = useMemo(() => {
 		if (!currentRoom || !myUser) return null;
 
 		return (
-			currentRoom.members?.find(
-				(member) => member.username !== myUser.username
-			) ?? null
+			currentRoom.memberIds
+				.map((memberId) => usersById[memberId])
+				.find((member) => member?.username !== myUser.username) ?? null
 		);
-	}, [currentRoom, myUser]);
+	}, [currentRoom, myUser, usersById]);
 
 	const roomTitle = useMemo(() => {
 		if (currentRoom?.type === "PRIVATE") {
@@ -173,12 +173,14 @@ export function DmChat() {
 				</div>
 			</div>
 
-			<RoomSettingModal
-				isOpen={isRoomSettingOpen}
-				onClose={() => setIsRoomSettingOpen(false)}
-				onStartCall={handleStartCall}
-				room={currentRoom}
-			/>
+			{currentRoom && (
+				<RoomSettingModal
+					isOpen={isRoomSettingOpen}
+					onClose={() => setIsRoomSettingOpen(false)}
+					onStartCall={handleStartCall}
+					room={currentRoom}
+				/>
+			)}
 
 			<DmItemsList />
 

--- a/src/pages/InboxLayout/InboxLayout.tsx
+++ b/src/pages/InboxLayout/InboxLayout.tsx
@@ -33,8 +33,9 @@ export function InboxLayout() {
 		call.presentationMode === "expanded" &&
 		call.isCallFocusMode;
 
-	const { rooms } = room;
+		const { rooms } = room;
 	const { friends } = friend
+	const usersById = useSelector((s: RootState) => s.users.usersById);
 	const unreadRoomCount = room.rooms.filter(r => r.unreadCount > 0).length;
 
 	useEffect(() => {
@@ -105,7 +106,7 @@ export function InboxLayout() {
 	const handleFriendClick = (friendUsername: string) => {
 		const existing = rooms.find(r =>
 			r.type === "PRIVATE" &&
-			r.members?.some(m => m.username === friendUsername)
+			r.memberIds?.some((memberId) => usersById[memberId]?.username === friendUsername)
 		)
 
 		if (existing) {

--- a/src/store/interfaces/rootState.interface.ts
+++ b/src/store/interfaces/rootState.interface.ts
@@ -1,20 +1,31 @@
-import type callSlice from "../slices/call.clice";
+import type callSlice from "../slices/call.slice";
+import type channelMessageSlice from "../slices/channelMessage.slice";
+import type deviceSlice from "../slices/device.slice";
 import type friendSlice from "../slices/friend.slice";
 import type messageSlice from "../slices/message.slice";
+import type notificationSlice from "../slices/notification.slice";
 import type roomSlice from "../slices/room.slice";
 import type serverSlice from "../slices/server.slice";
+import type toastSlice from "../slices/toast.slice";
+import type uiSlice from "../slices/ui.slice";
 import type userSlice from "../slices/user.slice";
+import type usersSlice from "../slices/users.slice";
 import type websocketSlice from "../slices/websocket.slice";
 
-
 export interface RootState {
-	user: ReturnType<typeof userSlice>
-	server: ReturnType<typeof serverSlice>,
-	room: ReturnType<typeof roomSlice>,
-	message: ReturnType<typeof messageSlice>,
-	friend: ReturnType<typeof friendSlice>,
-	websocket: ReturnType<typeof websocketSlice>,
-	call: ReturnType<typeof callSlice>
+	user: ReturnType<typeof userSlice>;
+	users: ReturnType<typeof usersSlice>;
+	server: ReturnType<typeof serverSlice>;
+	room: ReturnType<typeof roomSlice>;
+	message: ReturnType<typeof messageSlice>;
+	channelMessage: ReturnType<typeof channelMessageSlice>;
+	friend: ReturnType<typeof friendSlice>;
+	websocket: ReturnType<typeof websocketSlice>;
+	call: ReturnType<typeof callSlice>;
+	notification: ReturnType<typeof notificationSlice>;
+	toast: ReturnType<typeof toastSlice>;
+	device: ReturnType<typeof deviceSlice>;
+	ui: ReturnType<typeof uiSlice>;
 }
 
-export type AppDispatch = (action: any) => any;
+export type AppDispatch = any;

--- a/src/store/interfaces/userEvents.interface.ts
+++ b/src/store/interfaces/userEvents.interface.ts
@@ -1,0 +1,6 @@
+import type { UserShort } from "../../entities/userShort";
+
+export interface UserProfileUpdatedEvent {
+	type: "USER_PROFILE_UPDATED";
+	payload: UserShort;
+}

--- a/src/store/interfaces/wsPathes.ts
+++ b/src/store/interfaces/wsPathes.ts
@@ -9,10 +9,11 @@ export const WS_FRIEND_REQUESTS_PATH = `${USER_QUEUE_PREFIX}/friend-requests`;
 export const WS_ERROR_PATH = `${USER_QUEUE_PREFIX}/errors`;
 export const WS_MESSAGE_READ_PATH = `${USER_QUEUE_PREFIX}/message-read`;
 export const WS_ROOM_EVENTS_PATH = `${USER_QUEUE_PREFIX}/room-events`;
+export const WS_USER_EVENTS_PATH = `${USER_QUEUE_PREFIX}/user-events`;
 
 export const WS_SEND_MESSAGE_PATH = `${APP_CHAT_PREFIX}/send`;
-export const WS_SEND_PRIVATE_MESSAGE_PATH = `${APP_CHAT_PREFIX}/private`
-export const WS_SEND_CHANNEL_MESSAGE_PATH = `${APP_CHAT_PREFIX}/channel`
+export const WS_SEND_PRIVATE_MESSAGE_PATH = `${APP_CHAT_PREFIX}/private`;
+export const WS_SEND_CHANNEL_MESSAGE_PATH = `${APP_CHAT_PREFIX}/channel`;
 export const WS_EDIT_MESSAGE_PATH = `${APP_CHAT_PREFIX}/edit`;
 export const WS_DELETE_MESSAGE_PATH = `${APP_CHAT_PREFIX}/delete`;
 export const WS_UPDATE_READ_MESSAGE_PATH = `${APP_CHAT_PREFIX}/read`;

--- a/src/store/middlewares/websocket.middleware.ts
+++ b/src/store/middlewares/websocket.middleware.ts
@@ -4,8 +4,9 @@ import type { Actions } from "../interfaces/actions.interface";
 import { websocketActions } from "../slices/websocket.slice";
 import { createWebSocketClient } from "../../services/websocket.service";
 import { fetchRoomMessages, messageActions } from "../slices/message.slice";
-import { WS_ACCEPT_FRIEND_REQUEST_PATH, WS_CALL_PATH, WS_CANCEL_FRIEND_REQUEST_PATH, WS_DELETE_MESSAGE_PATH, WS_EDIT_MESSAGE_PATH, WS_ERROR_PATH, WS_FRIEND_REQUESTS_PATH, WS_MESSAGE_READ_PATH, WS_MESSAGES_PATH, WS_REJECT_FRIEND_REQUEST_PATH, WS_REMOVE_FRIEND_REQUEST_PATH, WS_ROOM_EVENTS_PATH, WS_SEND_ACCEPT_PATH, WS_SEND_CHANNEL_MESSAGE_PATH, WS_SEND_FRIEND_REQUEST_PATH, WS_SEND_INVITE_PATH, WS_SEND_MESSAGE_PATH, WS_SEND_PRIVATE_MESSAGE_PATH, WS_UPDATE_READ_MESSAGE_PATH } from "../interfaces/wsPathes";
+import { WS_ACCEPT_FRIEND_REQUEST_PATH, WS_CALL_PATH, WS_CANCEL_FRIEND_REQUEST_PATH, WS_DELETE_MESSAGE_PATH, WS_EDIT_MESSAGE_PATH, WS_ERROR_PATH, WS_FRIEND_REQUESTS_PATH, WS_MESSAGE_READ_PATH, WS_MESSAGES_PATH, WS_REJECT_FRIEND_REQUEST_PATH, WS_REMOVE_FRIEND_REQUEST_PATH, WS_ROOM_EVENTS_PATH, WS_SEND_ACCEPT_PATH, WS_SEND_CHANNEL_MESSAGE_PATH, WS_SEND_FRIEND_REQUEST_PATH, WS_SEND_INVITE_PATH, WS_SEND_MESSAGE_PATH, WS_SEND_PRIVATE_MESSAGE_PATH, WS_UPDATE_READ_MESSAGE_PATH, WS_USER_EVENTS_PATH } from "../interfaces/wsPathes";
 import { fetchMyRooms } from "../slices/room.slice";
+import { usersActions } from "../slices/users.slice";
 import type { BaseCallEvent, CallInviteEvent } from "../interfaces/callEvents.interface";
 import { callActions, getToken } from "../slices/call.slice";
 import type { AppDispatch, RootState } from "../interfaces/rootState.interface";
@@ -17,6 +18,7 @@ import { soundPlayer } from "../../utils/soundPlayer";
 import { channelMessageActions } from "../slices/channelMessage.slice";
 import type { MessageReadStatusContent } from "../../api/interfaces/MessageReadStatusContent";
 import type { RoomEvents } from "../../api/interfaces/RoomEvents";
+import type { UserProfileUpdatedEvent } from "../interfaces/userEvents.interface";
 
 
 export const websocketMiddleware: Middleware<{}, RootState, AppDispatch> = (storeApi) => {
@@ -214,6 +216,7 @@ export const websocketMiddleware: Middleware<{}, RootState, AppDispatch> = (stor
 					if (messageReadSub) subscriptions[WS_MESSAGE_READ_PATH] = messageReadSub;
 
 					const messageRoomEventsSub = client?.subscribe(WS_ROOM_EVENTS_PATH, (message) => {
+
 						const data = JSON.parse(message.body) as RoomEvents;
 
 						switch (data.type) {
@@ -223,6 +226,19 @@ export const websocketMiddleware: Middleware<{}, RootState, AppDispatch> = (stor
 							}
 						}
 					})
+					const userEventsSub = client?.subscribe(WS_USER_EVENTS_PATH, (message) => {
+						const data = JSON.parse(message.body) as UserProfileUpdatedEvent;
+
+						switch (data.type) {
+							case "USER_PROFILE_UPDATED": {
+								storeApi.dispatch(usersActions.userProfileUpdated(data.payload));
+								break;
+							}
+						}
+					});
+
+					if (userEventsSub) subscriptions[WS_USER_EVENTS_PATH] = userEventsSub;
+
 				};
 
 				client.activate();

--- a/src/store/selectors/roomUsers.selectors.ts
+++ b/src/store/selectors/roomUsers.selectors.ts
@@ -1,0 +1,43 @@
+import { createSelector } from "@reduxjs/toolkit";
+import type { Room } from "../../entities/room";
+import type { RoomMemberShort } from "../../entities/roomMember";
+import type { RootState } from "../store";
+
+export const selectUsersById = (state: RootState) => state.users.usersById;
+export const selectRooms = (state: RootState) => state.room.rooms;
+
+export const selectRoomById = (state: RootState, roomId: number) =>
+	state.room.rooms.find((room) => room.id === roomId) ?? null;
+
+const selectRoomForMembers = (_state: RootState, room: Room | null) => room;
+
+export const selectMembersFromRoom = createSelector(
+	[selectUsersById, selectRoomForMembers],
+	(usersById, room): RoomMemberShort[] => {
+		if (!room) return [];
+		return room.memberIds
+			.map((memberId) => usersById[memberId])
+			.filter((member): member is RoomMemberShort => member !== undefined);
+	}
+);
+
+export const selectRoomMembers = createSelector(
+	[selectRoomById, selectUsersById],
+	(room, usersById): RoomMemberShort[] => {
+		if (!room) return [];
+		return room.memberIds
+			.map((memberId) => usersById[memberId])
+			.filter((member): member is RoomMemberShort => member !== undefined);
+	}
+);
+
+export const selectRoomsWithMembers = createSelector(
+	[selectRooms, selectUsersById],
+	(rooms, usersById) =>
+		rooms.map((room) => ({
+			...room,
+			members: room.memberIds
+				.map((memberId) => usersById[memberId])
+				.filter((member): member is RoomMemberShort => member !== undefined),
+		}))
+);

--- a/src/store/slices/room.slice.ts
+++ b/src/store/slices/room.slice.ts
@@ -1,12 +1,19 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import type { Room } from "../../entities/room";
-import { roomApi } from "../../api/roomApi";
 import type { CreateGroupBody } from "../../api/interfaces/CreateGroupBody";
+import { roomApi } from "../../api/roomApi";
+import type { Room, RoomApiResponse } from "../../entities/room";
+import type { UserShort } from "../../entities/userShort";
+import { usersActions } from "./users.slice";
 
 export interface RoomState {
 	rooms: Room[];
 	status: "idle" | "loading" | "succeeded" | "failed";
 	error: string | null;
+}
+
+interface FetchRoomsNormalized {
+	rooms: Room[];
+	users: UserShort[];
 }
 
 const initialState: RoomState = {
@@ -15,17 +22,53 @@ const initialState: RoomState = {
 	error: null,
 };
 
+const normalizeRooms = (rooms: RoomApiResponse[]): FetchRoomsNormalized => {
+	const usersById: Record<number, UserShort> = {};
+
+	const normalizedRooms: Room[] = rooms.map((room) => {
+		room.members.forEach((member) => {
+			usersById[member.id] = {
+				...usersById[member.id],
+				...member,
+			};
+		});
+
+		return {
+			id: room.id,
+			name: room.name,
+			type: room.type,
+			avatarUrl: room.avatarUrl,
+			isActive: room.isActive,
+			createdAt: room.createdAt,
+			lastMessageId: room.lastMessageId,
+			lastMessageContent: room.lastMessageContent,
+			lastActivityAt: room.lastActivityAt,
+			unreadCount: room.unreadCount,
+			firstUnreadMessageId: room.firstUnreadMessageId,
+			memberIds: room.members.map((member) => member.id),
+		};
+	});
+
+	return {
+		rooms: normalizedRooms,
+		users: Object.values(usersById),
+	};
+};
+
 export const fetchMyRooms = createAsyncThunk(
 	"room/fetchMyRooms",
 	async (_, thunkAPI) => {
 		try {
 			const { data } = await roomApi.myRooms();
-			return data;
-		} catch (e: any) {
-			return thunkAPI.rejectWithValue(e?.message ?? "Failed to load rooms");
+			const normalized = normalizeRooms(data);
+			thunkAPI.dispatch(usersActions.upsertUsers(normalized.users));
+			return normalized;
+		} catch (e: unknown) {
+			const message = e instanceof Error ? e.message : "Failed to load rooms";
+			return thunkAPI.rejectWithValue(message);
 		}
 	}
-)
+);
 
 export const createGroupRoom = createAsyncThunk(
 	"room/createGroup",
@@ -33,11 +76,12 @@ export const createGroupRoom = createAsyncThunk(
 		try {
 			const { data } = await roomApi.createGroup(body);
 			return data;
-		} catch (e: any) {
-			return thunkAPI.rejectWithValue(e?.message ?? "Failed to create group room");
+		} catch (e: unknown) {
+			const message = e instanceof Error ? e.message : "Failed to create group room";
+			return thunkAPI.rejectWithValue(message);
 		}
 	}
-)
+);
 
 export const markRoomAsRead = createAsyncThunk(
 	"room/markRoomAsRead",
@@ -45,26 +89,26 @@ export const markRoomAsRead = createAsyncThunk(
 		try {
 			await roomApi.markRoomRead({ roomId: body.roomId });
 			return body.roomId;
-		} catch (e: any) {
-			return thunkAPI.rejectWithValue(e?.message ?? "Failed to mark room");
+		} catch (e: unknown) {
+			const message = e instanceof Error ? e.message : "Failed to mark room";
+			return thunkAPI.rejectWithValue(message);
 		}
-
 	}
-)
+);
 
 export const roomSlice = createSlice({
 	name: "room",
-	initialState: initialState,
+	initialState,
 	reducers: {},
-	extraReducers: builder => {
+	extraReducers: (builder) => {
 		builder
-			.addCase(fetchMyRooms.pending, currentState => {
+			.addCase(fetchMyRooms.pending, (currentState) => {
 				currentState.status = "loading";
 				currentState.error = null;
 			})
 			.addCase(fetchMyRooms.fulfilled, (currentState, action) => {
 				currentState.status = "succeeded";
-				currentState.rooms = action.payload;
+				currentState.rooms = action.payload.rooms;
 			})
 			.addCase(fetchMyRooms.rejected, (currentState, action) => {
 				currentState.status = "failed";
@@ -72,10 +116,10 @@ export const roomSlice = createSlice({
 			})
 
 			.addCase(markRoomAsRead.fulfilled, (currentState, action) => {
-				const room = currentState.rooms.find(r => r.id === action.payload);
+				const room = currentState.rooms.find((r) => r.id === action.payload);
 				if (room !== undefined) room.unreadCount = 0;
-			})
-	}
+			});
+	},
 });
 
 export default roomSlice.reducer;

--- a/src/store/slices/users.slice.ts
+++ b/src/store/slices/users.slice.ts
@@ -1,0 +1,39 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { UserShort } from "../../entities/userShort";
+
+export interface UsersState {
+	usersById: Record<number, UserShort>;
+}
+
+const initialState: UsersState = {
+	usersById: {},
+};
+
+const mergeUser = (state: UsersState, user: UserShort) => {
+	const existingUser = state.usersById[user.id];
+	state.usersById[user.id] = existingUser ? { ...existingUser, ...user } : user;
+};
+
+export const usersSlice = createSlice({
+	name: "users",
+	initialState,
+	reducers: {
+		upsertUser: (state, action: PayloadAction<UserShort>) => {
+			mergeUser(state, action.payload);
+		},
+		upsertUsers: (state, action: PayloadAction<UserShort[]>) => {
+			action.payload.forEach((user) => {
+				mergeUser(state, user);
+			});
+		},
+		userProfileUpdated: (state, action: PayloadAction<UserShort>) => {
+			mergeUser(state, action.payload);
+		},
+		clearUsers: (state) => {
+			state.usersById = {};
+		},
+	},
+});
+
+export default usersSlice.reducer;
+export const usersActions = usersSlice.actions;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -13,6 +13,7 @@ import toastSlice from "./slices/toast.slice";
 import deviceSlice from "./slices/device.slice";
 import uiSlice from "./slices/ui.slice";
 import channelMessageSlice from "./slices/channelMessage.slice";
+import usersSlice from "./slices/users.slice";
 
 
 const appReducer = combineReducers({
@@ -27,7 +28,8 @@ const appReducer = combineReducers({
 	notification: notificationSlice,
 	toast: toastSlice,
 	device: deviceSlice,
-	ui: uiSlice
+	ui: uiSlice,
+	users: usersSlice
 });
 
 const rootReducer = (state: ReturnType<typeof appReducer> | undefined, action: UnknownAction) => {


### PR DESCRIPTION
### Motivation
- Eliminate duplication of user/profile data embedded across `room.members`, message senders, friends etc. and centralize short user info in a single store to simplify realtime profile updates.  
- Prepare frontend to apply realtime updates (`avatarUrl`, `displayName`, `username`, `aboutMe`, `status`) without changing backend contracts.  
- Keep existing UI behavior while migrating internal state to a normalized shape (`memberIds` + `usersById`).

### Description
- Added a new `users` slice with `usersById: Record<number, UserShort>` and reducers `upsertUser`, `upsertUsers`, `userProfileUpdated`, `clearUsers` (`src/store/slices/users.slice.ts`).
- Introduced explicit entity types: `RoomApiResponse`, `RoomStateItem`/`Room`, `RoomMemberShort`, `UserShort`, and `UserProfileUpdatedEvent` and left API response typing unchanged on the backend surface (`src/entities/*`, `src/store/interfaces/userEvents.interface.ts`).
- Normalized room loading in `fetchMyRooms`: `RoomApiResponse[]` is converted to `{ rooms, users }`, users are upserted via `usersActions.upsertUsers(users)`, and room state stores `memberIds: number[]` (`src/store/slices/room.slice.ts`).
- Added selectors to reconstruct members when UI needs them: `selectUsersById`, `selectRoomMembers`, `selectRoomsWithMembers` (`src/store/selectors/roomUsers.selectors.ts`).
- Updated UI consumers to read members via `room.memberIds` + `usersById` rather than embedded `room.members` in components that previously accessed members: `InboxLayout`, `DmChat`, `RoomSettingModal`, `RoomListItem`, `RoomsList`, `CallUi` (files in `src/pages/*` and `src/components/*`).
- Added WS path constant `WS_USER_EVENTS_PATH = "/user/queue/user-events"` and subscribed to it in `websocket.middleware`; on receiving `{ type: "USER_PROFILE_UPDATED", payload: UserShort }` it dispatches `usersActions.userProfileUpdated(payload)` to update centralized user data (`src/store/interfaces/wsPathes.ts`, `src/store/middlewares/websocket.middleware.ts`).
- Registered the new `users` reducer in the root store so normalized user state is part of `RootState` (`src/store/store.ts`, `src/store/interfaces/rootState.interface.ts`).
- Kept backend API contracts intact while updating frontend API typings to expect `RoomApiResponse[]` for `myRooms`/`createGroup` so normalization remains frontend-only (`src/api/roomApi.ts`, `src/api/interfaces/RoomApiInterface.ts`).

### Testing
- Ran build/type-check: `npm run build`; the command ran and emitted TypeScript compilation diagnostics but the build failed due to pre-existing TypeScript errors in unrelated parts of the codebase (many `TS6133` unused variables and a few type mismatches); these errors are not introduced by the normalization changes and must be addressed separately.  
- No automated unit/integration tests were present to run in this repository (no test runner configured).  
- Manual static checks: verified that normalization flow dispatches `usersActions.upsertUsers` in `fetchMyRooms` and that `USER_PROFILE_UPDATED` WS events update `usersById` via `usersActions.userProfileUpdated`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe1324d40832ea35f74f81a2a9c4e)