### PR TITLE
Per-user audio mix, input sensitivity, and gaming screen-share presets with runtime fallbacks

### DIFF
--- a/docs/call-domain-notes.md
+++ b/docs/call-domain-notes.md
@@ -1,108 +1,120 @@
 # Call Domain Notes
 
-## Responsible Modules
+## 1. Screen share quality presets
 
-- `src/components/ActiveCallOverlay/ActiveCallOverlay.tsx` owns the active `LiveKitRoom`, call presentation modes, hidden bubble, and room-level call helpers.
-- `src/components/ActiveCallOverlay/MiniCallDock.tsx` renders minimized call controls.
-- `src/components/ActiveCallOverlay/MiniSpeakingStatus.tsx` renders aggregated LiveKit speaking state in minimized mode.
-- `src/components/ActiveCallOverlay/CallHotkeys.tsx` owns the global in-call microphone hotkey.
-- `src/components/ActiveCallOverlay/CallAudioLayer.tsx` renders subscribed remote microphone and screen share audio tracks.
-- `src/components/CallUi/CallUi.tsx` renders expanded call participants, camera tracks, selected screen share, screen-share tile states, and main controls.
-- `src/components/CallUi/MicrophoneToggleButton.tsx` toggles the real LiveKit microphone track and is reused by expanded and minimized controls.
-- `src/components/CallUi/useMicrophoneCaptureOptions.ts` builds selected microphone/noise suppression capture options from Redux device settings.
-- `src/components/CallUi/CallParticipantTile.tsx` renders each participant tile and uses LiveKit `participant.isSpeaking` / `participant.isMicrophoneEnabled`.
-- `src/components/CallUi/CallQualityController.tsx` applies active camera and screen share quality changes inside the LiveKit room context.
-- `src/utils/callQuality.ts` defines camera, microphone-adjacent, and screen share capture/publish quality helpers.
-- `src/store/slices/call.slice.ts` stores call status, LiveKit credentials, selected screen share track, and presentation mode. It does not store microphone mute or speaking state.
-- `src/store/slices/device.slice.ts` stores selected devices, noise suppression, camera quality, screen share quality, and connection-test recommendation.
+Source of truth: `src/utils/callQuality.ts`.
 
-## Track Creation And Publishing
+- `low`: 1280x720, 5 FPS, 0.8 Mbps.
+- `medium`: 1920x1080, 15 FPS, 2.5 Mbps.
+- `high`: 1920x1080, 30 FPS, 5 Mbps.
+- `game60`: 1920x1080, 60 FPS, 8 Mbps.
+- `game120`: 1920x1080, 120 FPS, 12 Mbps (experimental).
 
-- Microphone publishing is triggered through LiveKit React `useTrackToggle` / `TrackToggle` with `Track.Source.Microphone`.
-- `useMicrophoneCaptureOptions.ts` applies the selected microphone device and noise suppression options to microphone creation.
-- Camera publishing is triggered by `TrackToggle` with `Track.Source.Camera` in `CallUi.tsx`.
-- Screen share publishing is triggered by `TrackToggle` with `Track.Source.ScreenShare` in `CallUi.tsx`.
-- Multiple screen shares use a Discord-like model: participant tiles stay visible, the selected share opens in the main screen, and non-selected shares show static tile badges/placeholders instead of live previews.
-- Normal calls do not manually call `createLocalTracks`, `createScreenTracks`, or `publishTrack`; LiveKit React delegates to `room.localParticipant.setMicrophoneEnabled`, `setCameraEnabled`, and `setScreenShareEnabled`.
-- `getScreenShareCaptureOptions()` requests screen share audio with `audio: true` and `systemAudio: "include"`. LiveKit publishes `Track.Source.ScreenShareAudio` only when the browser/source returns an audio track from `getDisplayMedia`.
-- `CallUi.tsx` shows a local note when screen share video is active but no local `Track.Source.ScreenShareAudio` publication exists.
-- `CallUi.tsx` uses `RemoteTrackPublication.setSubscribed(...)` to keep non-selected remote screen share video unsubscribed where LiveKit allows it.
-- `CallAudioLayer.tsx` renders remote `Track.Source.ScreenShareAudio` only for the participant whose screen share is selected.
-- The app keeps LiveKit room `autoSubscribe` enabled globally; screen share optimization is done with targeted `setSubscribed(false)` after publications appear. Switching the whole room to `autoSubscribe: false` would require a broader manual subscription flow for microphone and camera too.
+Screen-share capture options are requested as ideal values (`resolution.width/height/frameRate`) and remain best-effort at browser/WebRTC level.
 
-## Speaking, Events, And Hotkeys
+## 2. Gaming screen share modes
 
-- Speaking UI uses LiveKit participant state through `useParticipants()` and `participant.isSpeaking`.
-- Expanded participant tiles highlight a speaking participant in `CallParticipantTile.tsx`.
-- Minimized speaking status aggregates current speakers in `MiniSpeakingStatus.tsx`.
-- Local speaking has priority and displays `Вы говорите`.
-- Remote speaking displays up to three names and then `+ ещё N`.
-- A short hold window smooths speaking state after LiveKit reports no active speaker, reducing flicker without fake timer-based speech.
-- Existing room events are used in `CallQualityController.tsx`: `RoomEvent.ConnectionQualityChanged` plus local sender stats.
-- The in-call mute hotkey is `Ctrl+Alt+M`, implemented in `CallHotkeys.tsx` through `room.localParticipant.setMicrophoneEnabled(...)`.
-- The hotkey accepts the physical Latin `M` key and Cyrillic `ь`/`м` key values to work predictably across English and Russian keyboard layouts.
-- The hotkey ignores key repeat, focused editable targets, and open modal-like DOM markers: `input`, `textarea`, `select`, `contenteditable`, `[aria-modal="true"]`, `[role="dialog"]`, and `[data-state="open"]`.
+- `game60` prioritizes smoother motion and lower perceived latency compared to regular screen presets.
+- `game120` is marked experimental in UI and quality metadata.
+- For high-FPS modes, publish defaults prefer `maintain-framerate` for screen share encoding.
 
-## Browser And LiveKit Limits
+## 3. Why 1080p120 is experimental / best effort
 
-- Screen share audio is browser/source dependent. The frontend can request audio, but cannot force the browser picker to include or return an audio track.
-- Common limitation: browser-tab audio may require the user to enable the browser's "share tab audio" or equivalent picker option.
-- If no screen share audio track is returned, screen share video should continue and remote playback remains limited to video.
-- The expanded call UI exposes this as a source/browser limitation note while local screen share video is active.
-- Non-selected remote screen shares may still appear as publications/metadata, but should not be rendered as live `<VideoTrack>` previews.
-- `CallAudioLayer.tsx` filters out local, unsubscribed, muted, and missing audio tracks before rendering.
-- Screen share resolution should not be restarted silently during an active share because browsers may show a picker again or interrupt capture.
-- Changing `LiveKitRoom options` during a call can recreate the LiveKit room; keep active quality changes in `TrackToggle` props and `CallQualityController`.
+`1080p120` is not guaranteed because real output depends on:
 
-## Safe Vs Risky Changes
+- browser implementation of `getDisplayMedia`;
+- selected source type (tab/window/monitor);
+- OS and GPU/encoder limits;
+- monitor refresh rate and source rendering rate;
+- current CPU/upload/network constraints.
 
-Safe:
-- Tune speaking hold timing in `MiniSpeakingStatus.tsx`.
-- Adjust minimized call layout and labels in `ActiveCallOverlay.module.css`.
-- Tune quality presets in `src/utils/callQuality.ts`.
-- Improve screen share audio copy/tooltips without changing LiveKit publishing flow.
+Runtime logic in `CallQualityController` reads `track.getSourceTrackSettings().frameRate` when available. For `game120` it applies fallback chain:
 
-Risky:
-- Adding a Redux mirror for microphone mute or speaking state.
-- Replacing LiveKit `useTrackToggle` / `TrackToggle` with custom publish/unpublish logic.
-- Changing call status strings or WebSocket call payloads without backend confirmation.
-- Recreating `LiveKitRoom` when device, quality, or presentation mode changes.
-- Restarting active screen share capture to force audio or resolution changes.
+- if actual FPS < 100 and >= 55 → fallback to `game60` sender encoding;
+- if actual FPS < 55 → fallback to `high` sender encoding.
 
-## Known Edge Cases
+UI in Voice/Video settings shows requested FPS, actual FPS, active applied mode, and fallback reason.
 
-- `Ctrl+Alt+M` should not toggle microphone while the user types in chat, edits a message, selects an input, uses contenteditable content, or has a modal with a known open marker.
-- Holding `Ctrl+Alt+M` should not repeatedly toggle mute because repeat keydown events are ignored.
-- Minimized mute button and expanded mute button must show the same LiveKit microphone state.
-- If local and remote participants speak at the same time, minimized status shows local priority: `Вы говорите`.
-- If four or more remote participants speak, minimized status shows the first three plus `+ ещё N`.
-- Screen share video without audio is expected when the browser/source does not provide an audio track.
-- The screen audio limitation note should appear for local screen share video without local `ScreenShareAudio`.
-- Remote screen share audio only plays for the currently selected screen share participant.
-- When the selected screen share ends, `CallUi.tsx` should select the next available screen share or clear selected state.
-- Leaving, reconnecting, or rejoining should reset call slice state through existing call lifecycle reducers.
+## 4. Per-user volume architecture
 
-## Manual QA Checklist
+- Local-only preference, no backend mutation.
+- Preferences are stored in Redux `device.participantVolumes` and persisted in `localStorage` key `device-preferences-v2`.
+- Key dimensions:
+  - `participantIdentity`;
+  - `source` (`microphone` or `screenShareAudio`).
+- Value range in current MVP: `0..100` (no boost above 100%).
+- UI surface: in-call `Audio Mix` panel in `CallUi`.
 
-- Start an outgoing DM call and accept an incoming call.
-- Toggle microphone in expanded call controls.
-- Minimize the call and toggle microphone from the mini button.
-- Press `Ctrl+Alt+M` once and confirm one mute state change.
-- Hold `Ctrl+Alt+M` and confirm there is no rapid repeated toggling.
-- Focus chat input, message edit input, and any textarea/select/contenteditable target; confirm the hotkey does not toggle microphone.
-- In minimized mode, test speaking status with nobody speaking, local speaking, one remote speaker, two remote speakers, three remote speakers, and four or more remote speakers.
-- Confirm the wave animation appears only when speaking status is active.
-- Start screen share from a source with audio support and confirm remote audio playback.
-- Start screen share from a source without audio or without selecting shared audio; confirm video continues and the call does not fail.
-- Confirm the screen audio limitation note appears only when local screen share video is active without local screen audio.
-- Start two or more simultaneous screen shares and confirm only the selected share is rendered in the main screen.
-- Confirm screen-sharing participants show tile badges/placeholders and open the main screen share on click.
-- Confirm remote screen share audio switches when selecting a different participant's screen share.
-- Leave call, rejoin, and verify call state resets.
-- Verify outgoing accept, incoming accept, decline, busy, and end events still follow existing WebSocket flow.
+## 5. Screen share audio volume architecture
 
-## Future Call UX Work
+- Separate slider/key from microphone volume.
+- Screen-share-audio slider appears only when remote `Track.Source.ScreenShareAudio` track exists.
+- Playback logic remains centralized in `CallAudioLayer`.
+- `CallAudioLayer` keeps existing behavior: screen-share-audio plays only for currently selected screen-share participant.
 
-- Use this document first when adding push-to-talk, device switching during a call, per-participant volume, screen share status badges, or call diagnostics.
-- Prefer extending the existing LiveKit room-context components instead of duplicating call state in Redux.
-- Open question: if product needs explicit "screen audio not shared" runtime feedback, add a small local screen share audio detector based on local `Track.Source.ScreenShareAudio` publication presence after share starts.
+## 6. Input sensitivity / voice threshold architecture
+
+Current implementation is safe MVP (frontend-only):
+
+- Setting is named `Input sensitivity / Voice activity threshold`.
+- It does not modify published microphone track.
+- It is used for local speaking UI thresholding and meter feedback.
+- Auto/manual toggle:
+  - auto threshold baseline: 30%;
+  - manual threshold range: 5..90.
+
+Related toggles in device settings:
+
+- noise suppression;
+- echo cancellation;
+- auto gain control.
+
+These map to browser capture constraints in `useMicrophoneCaptureOptions` and microphone preview constraints in `VoiceVideoSetting`.
+
+## 7. Noise gate / WebAudio limitations
+
+Full realtime mic processing (noise gate/high-pass/filter chain) is intentionally not included in this PR because it requires:
+
+- stable WebAudio processing graph for outgoing mic;
+- republish/restart coordination with LiveKit mute/unmute;
+- robust handling of device switching and reconnects;
+- careful artifact/performance testing across browsers.
+
+Open question: whether to implement processed outgoing track replacement in a dedicated follow-up after call-flow regression tests.
+
+## 8. Safe vs risky call/audio changes
+
+Safe in this iteration:
+
+- extending preset tables and UI mode selection;
+- runtime sender-encoding fallback for screen-share game120;
+- local-only per-user volume preferences;
+- speaking UI threshold tuning without touching published mic track.
+
+Risky (kept out of scope):
+
+- recreating `LiveKitRoom` on setting changes;
+- hidden screen-share restart / re-prompt from settings change;
+- replacing raw mic publish path with always-on WebAudio processor;
+- changing websocket call contracts.
+
+## 9. Manual QA for call/audio/screen-share features
+
+1. Select each legacy screen preset (`low/medium/high`) and start share.
+2. Select `game60`, start share, confirm call remains stable.
+3. Select `game120`, start share, verify fallback info if actual FPS is lower.
+4. Switch screen-share mode while active share is running; confirm no room recreation.
+5. Verify camera + screen share simultaneous behavior.
+6. Open `Audio Mix`, change remote mic volume, reset to default.
+7. If participant shares audio, adjust separate stream volume.
+8. Reconnect/rejoin and confirm volumes are re-applied.
+9. Toggle input sensitivity auto/manual and observe local speaking/meter behavior.
+10. Confirm mute/unmute and device selection still work.
+
+## 10. Future improvements
+
+- Optional WebAudio gain stage for >100% per-user boost (separate guarded feature flag).
+- Full outgoing mic processing pipeline (noise gate + optional high-pass filter) with controlled republish path.
+- Better automatic input-threshold calibration against ambient noise floor.
+- Live call diagnostics panel (send/recv bitrate, FPS, packet loss) with recommendations.
+- Optional backend sync for user AV preferences across devices (currently local only).

--- a/docs/call-domain-notes.md
+++ b/docs/call-domain-notes.md
@@ -1,120 +1,97 @@
 # Call Domain Notes
 
-## 1. Screen share quality presets
+## Participant context menu architecture
 
-Source of truth: `src/utils/callQuality.ts`.
+- Entry point: `CallUi.tsx` stores `participantMenu` state (`x`, `y`, `participantIdentity`).
+- Trigger: right-click (`onContextMenu`) on `CallParticipantTile`.
+- Menu UI: `src/components/CallUi/ParticipantContextMenu/ParticipantContextMenu.tsx`.
+- Volume controls inside menu: `ParticipantVolumeMenu` + shared `ParticipantVolumeRow`.
+- Dismiss behavior: `useDismissibleLayer` (Escape, scroll, resize) + outside click container close.
+- Positioning: menu coordinates are clamped to viewport before opening.
 
-- `low`: 1280x720, 5 FPS, 0.8 Mbps.
-- `medium`: 1920x1080, 15 FPS, 2.5 Mbps.
-- `high`: 1920x1080, 30 FPS, 5 Mbps.
-- `game60`: 1920x1080, 60 FPS, 8 Mbps.
-- `game120`: 1920x1080, 120 FPS, 12 Mbps (experimental).
+## User profile/popover architecture
 
-Screen-share capture options are requested as ideal values (`resolution.width/height/frameRate`) and remain best-effort at browser/WebRTC level.
+- Popover state lives in `CallUi.tsx` (`profilePopover`).
+- UI component: `src/components/CallUi/UserProfilePopover/UserProfilePopover.tsx`.
+- Content reuses existing `UserProfileCard` component.
+- Open path: context menu action `Open profile`.
+- Close path: outside click + Escape/scroll/resize via `useDismissibleLayer`.
 
-## 2. Gaming screen share modes
+## Camera preview architecture and cleanup rules
 
-- `game60` prioritizes smoother motion and lower perceived latency compared to regular screen presets.
-- `game120` is marked experimental in UI and quality metadata.
-- For high-FPS modes, publish defaults prefer `maintain-framerate` for screen share encoding.
+- Camera preview was extracted from monolithic settings logic:
+  - hook: `src/components/VoiceVideoSetting/CameraPreview/useCameraPreview.ts`
+  - UI: `CameraPreviewCard` + `CameraPreviewState`
+- Preview capture source: `getUserMedia` only (not published to LiveKit room).
+- Capture constraints use existing quality helpers (`getCameraCaptureOptions` + camera quality preset resolution).
+- Cleanup rules:
+  1. stop old preview tracks before creating a new stream;
+  2. clear `video.srcObject = null` on re-create and unmount;
+  3. stop all preview tracks on component cleanup.
+- Error states are explicit: `denied`, `not_found`, `no_device`, `error`.
 
-## 3. Why 1080p120 is experimental / best effort
+## Noise suppression architecture
 
-`1080p120` is not guaranteed because real output depends on:
+- Device settings live in `device.slice.ts` (`noiseSuppression`, `echoCancellation`, `autoGainControl`).
+- Capture options builder: `useMicrophoneCaptureOptions.ts`.
+- Microphone toggle/hotkey uses those options when enabling mic.
+- Runtime sync pass: `MicrophoneSettingsSync` re-applies capture options to active local mic track when settings change and mic is enabled.
+- This keeps the behavior in frontend + LiveKit API boundaries without backend changes.
 
-- browser implementation of `getDisplayMedia`;
-- selected source type (tab/window/monitor);
-- OS and GPU/encoder limits;
-- monitor refresh rate and source rendering rate;
-- current CPU/upload/network constraints.
+## Enhanced noise suppression / Krisp plan
 
-Runtime logic in `CallQualityController` reads `track.getSourceTrackSettings().frameRate` when available. For `game120` it applies fallback chain:
+Current status: Krisp is **not enabled in this pass** to avoid call-flow regressions.
 
-- if actual FPS < 100 and >= 55 → fallback to `game60` sender encoding;
-- if actual FPS < 55 → fallback to `high` sender encoding.
+Safe integration plan:
+1. Add optional "Enhanced noise suppression" toggle in device settings.
+2. Dynamic import `@livekit/krisp-noise-filter` only when toggle is enabled.
+3. Check support via Krisp support API before applying processor.
+4. Apply processor only to current local microphone track.
+5. On mic track change/recreate, re-attach processor once (no duplicate processors).
+6. On toggle off / unsupported / error, dispose processor and fallback to standard WebRTC noise suppression.
 
-UI in Voice/Video settings shows requested FPS, actual FPS, active applied mode, and fallback reason.
+Open question: exact processor lifecycle hooks for the current LiveKit track re-creation path should be validated in browser matrix before default rollout.
 
-## 4. Per-user volume architecture
+## Theater mode architecture
 
-- Local-only preference, no backend mutation.
-- Preferences are stored in Redux `device.participantVolumes` and persisted in `localStorage` key `device-preferences-v2`.
-- Key dimensions:
-  - `participantIdentity`;
-  - `source` (`microphone` or `screenShareAudio`).
-- Value range in current MVP: `0..100` (no boost above 100%).
-- UI surface: in-call `Audio Mix` panel in `CallUi`.
+- Call state expanded with `isTheaterMode` in `call.slice.ts`.
+- Trigger points:
+  - dedicated control button in `CallUi`;
+  - context menu action `Open theater mode`.
+- View component: `src/components/CallUi/TheaterMode/TheaterModeView.tsx`.
+- Theater mode uses existing selected screen-share flow (`selectedScreenTrackSid`) and does not alter screen-audio routing semantics.
+- Escape exits theater mode.
+- If selected screen share disappears, theater mode auto-exits.
 
-## 5. Screen share audio volume architecture
+## Safe/risky call UI changes
 
-- Separate slider/key from microphone volume.
-- Screen-share-audio slider appears only when remote `Track.Source.ScreenShareAudio` track exists.
-- Playback logic remains centralized in `CallAudioLayer`.
-- `CallAudioLayer` keeps existing behavior: screen-share-audio plays only for currently selected screen-share participant.
+Safe:
+- presentation refactor into small UI components;
+- context menus and popovers with local UI state;
+- camera preview via isolated `getUserMedia` stream;
+- microphone settings re-apply using existing LiveKit participant API.
 
-## 6. Input sensitivity / voice threshold architecture
+Risky:
+- modifying `CallAudioLayer` subscribe/playback semantics;
+- reworking `LiveKitRoom` props/lifecycle;
+- changing websocket call contracts;
+- introducing heavyweight audio processing in active call path without fallback.
 
-Current implementation is safe MVP (frontend-only):
+## Manual QA checklist
 
-- Setting is named `Input sensitivity / Voice activity threshold`.
-- It does not modify published microphone track.
-- It is used for local speaking UI thresholding and meter feedback.
-- Auto/manual toggle:
-  - auto threshold baseline: 30%;
-  - manual threshold range: 5..90.
-
-Related toggles in device settings:
-
-- noise suppression;
-- echo cancellation;
-- auto gain control.
-
-These map to browser capture constraints in `useMicrophoneCaptureOptions` and microphone preview constraints in `VoiceVideoSetting`.
-
-## 7. Noise gate / WebAudio limitations
-
-Full realtime mic processing (noise gate/high-pass/filter chain) is intentionally not included in this PR because it requires:
-
-- stable WebAudio processing graph for outgoing mic;
-- republish/restart coordination with LiveKit mute/unmute;
-- robust handling of device switching and reconnects;
-- careful artifact/performance testing across browsers.
-
-Open question: whether to implement processed outgoing track replacement in a dedicated follow-up after call-flow regression tests.
-
-## 8. Safe vs risky call/audio changes
-
-Safe in this iteration:
-
-- extending preset tables and UI mode selection;
-- runtime sender-encoding fallback for screen-share game120;
-- local-only per-user volume preferences;
-- speaking UI threshold tuning without touching published mic track.
-
-Risky (kept out of scope):
-
-- recreating `LiveKitRoom` on setting changes;
-- hidden screen-share restart / re-prompt from settings change;
-- replacing raw mic publish path with always-on WebAudio processor;
-- changing websocket call contracts.
-
-## 9. Manual QA for call/audio/screen-share features
-
-1. Select each legacy screen preset (`low/medium/high`) and start share.
-2. Select `game60`, start share, confirm call remains stable.
-3. Select `game120`, start share, verify fallback info if actual FPS is lower.
-4. Switch screen-share mode while active share is running; confirm no room recreation.
-5. Verify camera + screen share simultaneous behavior.
-6. Open `Audio Mix`, change remote mic volume, reset to default.
-7. If participant shares audio, adjust separate stream volume.
-8. Reconnect/rejoin and confirm volumes are re-applied.
-9. Toggle input sensitivity auto/manual and observe local speaking/meter behavior.
-10. Confirm mute/unmute and device selection still work.
-
-## 10. Future improvements
-
-- Optional WebAudio gain stage for >100% per-user boost (separate guarded feature flag).
-- Full outgoing mic processing pipeline (noise gate + optional high-pass filter) with controlled republish path.
-- Better automatic input-threshold calibration against ambient noise floor.
-- Live call diagnostics panel (send/recv bitrate, FPS, packet loss) with recommendations.
-- Optional backend sync for user AV preferences across devices (currently local only).
+1. Right-click on participant tile opens menu.
+2. Menu is clamped in viewport and closes by Escape/outside click/scroll/resize.
+3. Left-click screen-share selection still works.
+4. Context menu mic volume changes only target participant mic audio.
+5. Stream volume row appears only when screen-share-audio exists.
+6. Profile popover opens and closes predictably.
+7. Camera preview updates after camera device change.
+8. Camera preview updates after camera quality change.
+9. Closing settings releases preview stream.
+10. Active call camera publish flow remains stable while preview is used.
+11. Noise/echo/agc toggles re-apply to active mic track when mic is enabled.
+12. Theater mode opens selected screen share in focused layout.
+13. Escape exits theater mode.
+14. Ending selected screen share exits theater mode safely.
+15. Minimized/expanded/hidden call modes still work.
+16. Screen-share audio routing continues to follow selected screen-share participant.

--- a/src/components/ActiveCallOverlay/ActiveCallOverlay.tsx
+++ b/src/components/ActiveCallOverlay/ActiveCallOverlay.tsx
@@ -12,6 +12,7 @@ import { getQualityPreset, getVideoEncoding } from "../../utils/callQuality";
 import { CallQualityController } from "../CallUi/CallQualityController";
 import { CallHotkeys } from "./CallHotkeys";
 import { MiniCallDock } from "./MiniCallDock";
+import { MicrophoneSettingsSync } from "../CallUi/MicrophoneSettingsSync";
 
 export function ActiveCallOverlay() {
 	const [callHeight, setCallHeight] = useState(52);
@@ -112,6 +113,7 @@ export function ActiveCallOverlay() {
 				<CallAudioLayer />
 				<CallQualityController />
 				<CallHotkeys />
+				<MicrophoneSettingsSync />
 
 				{isExpanded && (
 					<div

--- a/src/components/ActiveCallOverlay/CallAudioLayer.tsx
+++ b/src/components/ActiveCallOverlay/CallAudioLayer.tsx
@@ -1,12 +1,20 @@
 import { AudioTrack, useTracks } from "@livekit/components-react";
-import { RemoteTrackPublication, Track } from "livekit-client";
+import {
+	RemoteAudioTrack,
+	RemoteTrackPublication,
+	Track,
+} from "livekit-client";
 import { useEffect, useMemo } from "react";
 import { useSelector } from "react-redux";
 import type { RootState } from "../../store/store";
+import type { ParticipantAudioSource } from "../../store/slices/device.slice";
 
 export function CallAudioLayer() {
 	const selectedScreenTrackSid = useSelector(
 		(s: RootState) => s.call.selectedScreenTrackSid
+	);
+	const participantVolumes = useSelector(
+		(s: RootState) => s.device.participantVolumes
 	);
 	const microphoneTracks = useTracks([Track.Source.Microphone]);
 	const screenTracks = useTracks([Track.Source.ScreenShare], {
@@ -50,6 +58,26 @@ export function CallAudioLayer() {
 		[microphoneTracks, screenAudioTracks, selectedScreenParticipantIdentity]
 	);
 
+	useEffect(() => {
+		audioTracks.forEach((trackRef) => {
+			const publication = trackRef.publication;
+			const track = publication?.track;
+			if (!(track instanceof RemoteAudioTrack)) return;
+			if (trackRef.participant.isLocal) return;
+
+			const source = toAudioSource(trackRef.source ?? publication?.source);
+			if (!source) return;
+
+			const preference = participantVolumes.find(
+				(item) =>
+					item.participantIdentity === trackRef.participant.identity &&
+					item.source === source
+			);
+			const volume = preference?.volume ?? 100;
+			track.setVolume(Math.max(0, Math.min(1, volume / 100)));
+		});
+	}, [audioTracks, participantVolumes]);
+
 	return (
 		<div aria-hidden="true" style={{ display: "none" }}>
 			{audioTracks.map((trackRef, index) => {
@@ -68,4 +96,10 @@ export function CallAudioLayer() {
 			})}
 		</div>
 	);
+}
+
+function toAudioSource(trackSource: Track.Source | undefined): ParticipantAudioSource | null {
+	if (trackSource === Track.Source.Microphone) return "microphone";
+	if (trackSource === Track.Source.ScreenShareAudio) return "screenShareAudio";
+	return null;
 }

--- a/src/components/ActiveCallOverlay/MiniSpeakingStatus.tsx
+++ b/src/components/ActiveCallOverlay/MiniSpeakingStatus.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParticipants } from "@livekit/components-react";
+import { useSelector } from "react-redux";
 import styles from "./ActiveCallOverlay.module.css";
+import type { RootState } from "../../store/store";
 
 interface SpeakingParticipant {
 	identity: string;
@@ -12,13 +14,22 @@ const MAX_VISIBLE_SPEAKERS = 3;
 
 export function MiniSpeakingStatus() {
 	const participants = useParticipants();
+	const { voiceActivityThreshold, isAutoInputSensitivity } = useSelector(
+		(state: RootState) => state.device
+	);
 	const clearTimerRef = useRef<number | null>(null);
 	const [displayedSpeakers, setDisplayedSpeakers] = useState<SpeakingParticipant[]>([]);
 
 	const currentSpeakers = useMemo(
 		() =>
 			participants
-				.filter((participant) => participant.isSpeaking)
+				.filter((participant) => {
+					if (participant.isLocal) {
+						const threshold = (isAutoInputSensitivity ? 30 : voiceActivityThreshold) / 100;
+						return participant.audioLevel >= threshold;
+					}
+					return participant.isSpeaking;
+				})
 				.sort((left, right) => {
 					if (left.isLocal !== right.isLocal) return left.isLocal ? -1 : 1;
 					return left.identity.localeCompare(right.identity);
@@ -27,7 +38,7 @@ export function MiniSpeakingStatus() {
 					identity: participant.name || "Unknown",
 					isLocal: participant.isLocal,
 				})),
-		[participants]
+		[participants, isAutoInputSensitivity, voiceActivityThreshold]
 	);
 
 	useEffect(() => {

--- a/src/components/CallUi/AudioMixPanel/AudioMixPanel.module.css
+++ b/src/components/CallUi/AudioMixPanel/AudioMixPanel.module.css
@@ -1,0 +1,116 @@
+.panel {
+	max-height: 220px;
+	overflow: auto;
+	padding: 10px;
+	border-radius: 10px;
+	border: 1px solid var(--border);
+	background: var(--bg-secondary);
+}
+
+.title {
+	font-weight: 700;
+	margin-bottom: 8px;
+}
+
+.empty {
+	padding: 10px;
+	border-radius: 10px;
+	border: 1px solid var(--border);
+	font-size: 13px;
+	color: var(--text-secondary);
+	background: var(--bg-secondary);
+}
+
+.participant {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 8px 0;
+	border-top: 1px solid var(--border);
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.avatar {
+	width: 24px;
+	height: 24px;
+	border-radius: 999px;
+	background: var(--bg-hover);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 12px;
+	font-weight: 700;
+	overflow: hidden;
+	flex-shrink: 0;
+}
+
+.avatarImage {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.name {
+	font-size: 13px;
+	font-weight: 600;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.row {
+	display: grid;
+	grid-template-columns: 74px minmax(0, 1fr) 46px 32px;
+	gap: 8px;
+	align-items: center;
+}
+
+.source {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.row input[type="range"] {
+	width: 100%;
+}
+
+.row input[type="range"]:focus-visible,
+.reset:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+.percent {
+	text-align: right;
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.reset {
+	height: 30px;
+	border: none;
+	border-radius: 8px;
+	background: var(--bg-hover);
+	color: var(--text-primary);
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.reset:hover {
+	background: var(--bg-active);
+}
+
+.reset:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}

--- a/src/components/CallUi/AudioMixPanel/AudioMixPanel.tsx
+++ b/src/components/CallUi/AudioMixPanel/AudioMixPanel.tsx
@@ -1,0 +1,74 @@
+import styles from "./AudioMixPanel.module.css";
+import { ParticipantVolumeRow } from "./ParticipantVolumeRow";
+
+export interface AudioMixParticipantItem {
+	identity: string;
+	displayName: string;
+	avatarUrl: string | null;
+	avatarLabel: string;
+	micAvailable: boolean;
+	streamAvailable: boolean;
+	micVolume: number;
+	streamVolume: number;
+}
+
+interface AudioMixPanelProps {
+	participants: AudioMixParticipantItem[];
+	hasAnyRemoteAudioTracks: boolean;
+	onMicVolumeChange: (participantIdentity: string, value: number) => void;
+	onMicReset: (participantIdentity: string) => void;
+	onStreamVolumeChange: (participantIdentity: string, value: number) => void;
+	onStreamReset: (participantIdentity: string) => void;
+}
+
+export function AudioMixPanel({
+	participants,
+	hasAnyRemoteAudioTracks,
+	onMicVolumeChange,
+	onMicReset,
+	onStreamVolumeChange,
+	onStreamReset,
+}: AudioMixPanelProps) {
+	if (participants.length === 0) {
+		return <div className={styles["empty"]}>No remote participants yet.</div>;
+	}
+
+	if (!hasAnyRemoteAudioTracks) {
+		return <div className={styles["empty"]}>Remote audio tracks are not available yet.</div>;
+	}
+
+	return (
+		<div className={styles["panel"]}>
+			<div className={styles["title"]}>Participant volume</div>
+			{participants.map((participant) => (
+				<div key={participant.identity} className={styles["participant"]}>
+					<div className={styles["header"]}>
+						<div className={styles["avatar"]}>
+							{participant.avatarUrl ? (
+								<img src={participant.avatarUrl} alt={`${participant.displayName} avatar`} className={styles["avatarImage"]} />
+							) : (
+								<span>{participant.avatarLabel}</span>
+							)}
+						</div>
+						<div className={styles["name"]} title={participant.displayName}>{participant.displayName}</div>
+					</div>
+					<ParticipantVolumeRow
+						source="microphone"
+						value={participant.micVolume}
+						disabled={!participant.micAvailable}
+						onChange={(value) => onMicVolumeChange(participant.identity, value)}
+						onReset={() => onMicReset(participant.identity)}
+					/>
+					{participant.streamAvailable && (
+						<ParticipantVolumeRow
+							source="screenShareAudio"
+							value={participant.streamVolume}
+							onChange={(value) => onStreamVolumeChange(participant.identity, value)}
+							onReset={() => onStreamReset(participant.identity)}
+						/>
+					)}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/src/components/CallUi/AudioMixPanel/ParticipantVolumeRow.tsx
+++ b/src/components/CallUi/AudioMixPanel/ParticipantVolumeRow.tsx
@@ -1,0 +1,45 @@
+import { Mic, MonitorUp, RotateCcw } from "lucide-react";
+import styles from "./AudioMixPanel.module.css";
+
+interface ParticipantVolumeRowProps {
+	source: "microphone" | "screenShareAudio";
+	value: number;
+	onChange: (next: number) => void;
+	onReset: () => void;
+	disabled?: boolean;
+}
+
+export function ParticipantVolumeRow({
+	source,
+	value,
+	onChange,
+	onReset,
+	disabled = false,
+}: ParticipantVolumeRowProps) {
+	return (
+		<div className={styles["row"]}>
+			<div className={styles["source"]}>
+				{source === "microphone" ? <Mic size={14} /> : <MonitorUp size={14} />}
+				<span>{source === "microphone" ? "Mic" : "Stream"}</span>
+			</div>
+			<input
+				type="range"
+				min={0}
+				max={100}
+				value={value}
+				disabled={disabled}
+				onChange={(event) => onChange(Number(event.target.value))}
+			/>
+			<span className={styles["percent"]}>{value}%</span>
+			<button
+				type="button"
+				disabled={disabled}
+				onClick={onReset}
+				title="Reset to 100%"
+				className={styles["reset"]}
+			>
+				<RotateCcw size={13} />
+			</button>
+		</div>
+	);
+}

--- a/src/components/CallUi/CallParticipantTile.props.ts
+++ b/src/components/CallUi/CallParticipantTile.props.ts
@@ -1,5 +1,6 @@
 import type { TrackReference } from "@livekit/components-react";
 import type { Participant } from "livekit-client";
+import type { MouseEvent } from "react";
 
 export interface CallParticipantTileProps {
 	participant: Participant;
@@ -9,5 +10,5 @@ export interface CallParticipantTileProps {
 	isScreenSharing?: boolean;
 	isScreenShareSelected?: boolean;
 	onOpenScreenShare?: () => void;
+	onContextMenu?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
-

--- a/src/components/CallUi/CallParticipantTile.tsx
+++ b/src/components/CallUi/CallParticipantTile.tsx
@@ -1,8 +1,10 @@
 import { MonitorUp, Mic, MicOff } from "lucide-react";
 import { VideoTrack } from "@livekit/components-react";
+import { useSelector } from "react-redux";
 import { StringToColor } from "../../utils/stringHelpers";
 import styles from "./CallUi.module.css";
 import type { CallParticipantTileProps } from "./CallParticipantTile.props";
+import type { RootState } from "../../store/store";
 
 export function CallParticipantTile({
 	participant,
@@ -13,11 +15,17 @@ export function CallParticipantTile({
 	isScreenShareSelected = false,
 	onOpenScreenShare,
 }: CallParticipantTileProps) {
+	const { voiceActivityThreshold, isAutoInputSensitivity } = useSelector(
+		(state: RootState) => state.device
+	);
 	const identity = participant.name || "Unknown";
 	const avatarLabel = identity.slice(0, 1).toUpperCase();
 	const avatarBg = StringToColor(identity);
 	const micEnabled = participant.isMicrophoneEnabled;
-	const isSpeaking = participant.isSpeaking;
+	const localThreshold = (isAutoInputSensitivity ? 30 : voiceActivityThreshold) / 100;
+	const isSpeaking = participant.isLocal
+		? participant.audioLevel >= localThreshold
+		: participant.isSpeaking;
 	const isClickableScreenShare = isScreenSharing && onOpenScreenShare;
 
 	return (

--- a/src/components/CallUi/CallParticipantTile.tsx
+++ b/src/components/CallUi/CallParticipantTile.tsx
@@ -14,6 +14,7 @@ export function CallParticipantTile({
 	isScreenSharing = false,
 	isScreenShareSelected = false,
 	onOpenScreenShare,
+	onContextMenu,
 }: CallParticipantTileProps) {
 	const { voiceActivityThreshold, isAutoInputSensitivity } = useSelector(
 		(state: RootState) => state.device
@@ -31,8 +32,8 @@ export function CallParticipantTile({
 	return (
 		<button
 			type="button"
-			disabled={!isClickableScreenShare}
 			onClick={isClickableScreenShare ? onOpenScreenShare : undefined}
+			onContextMenu={onContextMenu}
 			className={[
 				className,
 				styles["participant-card"],

--- a/src/components/CallUi/CallQualityController.tsx
+++ b/src/components/CallUi/CallQualityController.tsx
@@ -1,6 +1,6 @@
 import { useRoomContext } from "@livekit/components-react";
 import { useEffect, useMemo, useRef } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import {
 	ConnectionQuality,
 	LocalVideoTrack,
@@ -9,14 +9,16 @@ import {
 	VideoQuality,
 	type Participant,
 } from "livekit-client";
-import type { RootState } from "../../store/store";
+import type { AppDispatch, RootState } from "../../store/store";
 import {
 	getCameraCaptureOptions,
 	getQualityPreset,
 	resolveQualitySetting,
 	type CallMediaKind,
 	type ManualCallQuality,
+	type ScreenShareManualQuality,
 } from "../../utils/callQuality";
+import { deviceActions } from "../../store/slices/device.slice";
 
 type AutoPressure = 0 | 1 | 2;
 
@@ -41,6 +43,7 @@ const APPLY_DEBOUNCE_MS = 450;
 
 export function CallQualityController() {
 	const room = useRoomContext();
+	const dispatch = useDispatch<AppDispatch>();
 	const device = useSelector((s: RootState) => s.device);
 	const recommendation = device.connectionTestResult.recommendation;
 
@@ -49,8 +52,8 @@ export function CallQualityController() {
 		[device.cameraQuality, recommendation]
 	);
 	const initialScreenQuality = useMemo(
-		() => resolveQualitySetting("screenShare", device.screenShareQuality, recommendation),
-		[device.screenShareQuality, recommendation]
+		() => normalizeToManualQuality(recommendation?.screenShareQuality),
+		[recommendation?.screenShareQuality]
 	);
 
 	const connectionQualityRef = useRef<ConnectionQuality>(ConnectionQuality.Unknown);
@@ -131,7 +134,7 @@ export function CallQualityController() {
 
 	const queueApply = (
 		kind: CallMediaKind,
-		quality: ManualCallQuality,
+		quality: ManualCallQuality | ScreenShareManualQuality,
 		includeResolutionRestart: boolean
 	) => {
 		const previousTimer = applyTimersRef.current[kind];
@@ -239,7 +242,7 @@ export function CallQualityController() {
 
 	const applyQuality = async (
 		kind: CallMediaKind,
-		quality: ManualCallQuality,
+		quality: ManualCallQuality | ScreenShareManualQuality,
 		options: {
 			includeResolutionRestart: boolean;
 			includeFrameRate: boolean;
@@ -248,12 +251,44 @@ export function CallQualityController() {
 		const track = getLocalVideoTrack(kind);
 		if (!track) return;
 
-		const preset = getQualityPreset(kind, quality);
+		const preset =
+			kind === "camera"
+				? getQualityPreset("camera", quality as ManualCallQuality)
+				: getQualityPreset("screenShare", quality as ScreenShareManualQuality);
 
 		await setSenderEncoding(track, preset.maxBitrate, options.includeFrameRate ? preset.frameRate : null);
 
 		if (kind === "screenShare") {
 			track.setPublishingQuality(toVideoQuality(quality));
+			const settings = track.getSourceTrackSettings();
+			const actualFps =
+				typeof settings.frameRate === "number"
+					? Math.round(settings.frameRate)
+					: null;
+			const fallbackPreset = resolveScreenShareFallbackPreset(
+				quality as ScreenShareManualQuality,
+				actualFps
+			);
+			const fallbackReason = resolveScreenShareFallbackReason(
+				quality as ScreenShareManualQuality,
+				actualFps,
+				fallbackPreset
+			);
+			const appliedPreset = fallbackPreset
+				? getQualityPreset("screenShare", fallbackPreset)
+				: preset;
+			if (fallbackPreset) {
+				await setSenderEncoding(track, appliedPreset.maxBitrate, appliedPreset.frameRate);
+				track.setPublishingQuality(toVideoQuality(fallbackPreset));
+			}
+			dispatch(
+				deviceActions.setScreenShareRuntimeInfo({
+					requestedFps: preset.frameRate,
+					actualFps,
+					activePreset: appliedPreset.value,
+					fallbackReason,
+				})
+			);
 			return;
 		}
 
@@ -302,6 +337,32 @@ export function CallQualityController() {
 	return null;
 }
 
+function resolveScreenShareFallbackReason(
+	quality: ScreenShareManualQuality,
+	actualFps: number | null,
+	fallbackPreset: ScreenShareManualQuality | null
+) {
+	if (actualFps === null) return null;
+	if (quality !== "game120") return null;
+	if (actualFps >= 100) return null;
+	if (fallbackPreset === "game60") {
+		return "120 FPS is not available on this browser/source. Using 60 FPS best effort.";
+	}
+	return "High FPS screen share is limited by browser/source or device. Falling back to lower motion quality.";
+}
+
+function resolveScreenShareFallbackPreset(
+	quality: ScreenShareManualQuality,
+	actualFps: number | null
+): ScreenShareManualQuality | null {
+	if (quality !== "game120" || actualFps === null || actualFps >= 100) {
+		return null;
+	}
+
+	if (actualFps >= 55) return "game60";
+	return "high";
+}
+
 async function setSenderEncoding(
 	track: LocalVideoTrack,
 	maxBitrate: number,
@@ -341,8 +402,19 @@ function getHigherQuality(quality: ManualCallQuality): ManualCallQuality {
 	return QUALITY_ORDER[Math.min(QUALITY_ORDER.length - 1, currentIndex + 1)];
 }
 
-function toVideoQuality(quality: ManualCallQuality): VideoQuality {
-	if (quality === "high") return VideoQuality.HIGH;
+function toVideoQuality(quality: ManualCallQuality | ScreenShareManualQuality): VideoQuality {
+	if (quality === "high" || quality === "game60" || quality === "game120") {
+		return VideoQuality.HIGH;
+	}
 	if (quality === "medium") return VideoQuality.MEDIUM;
 	return VideoQuality.LOW;
+}
+
+function normalizeToManualQuality(
+	quality: ScreenShareManualQuality | undefined
+): ManualCallQuality {
+	if (quality === "game60" || quality === "game120") {
+		return "high";
+	}
+	return quality ?? "medium";
 }

--- a/src/components/CallUi/CallUi.module.css
+++ b/src/components/CallUi/CallUi.module.css
@@ -423,6 +423,59 @@
 	padding: 0 8px;
 }
 
+.audio-panel {
+	flex-shrink: 0;
+	max-height: 200px;
+	overflow: auto;
+	padding: 10px;
+	border-radius: 10px;
+	border: 1px solid var(--border);
+	background: var(--bg-secondary);
+}
+
+.audio-panel-title {
+	font-weight: 700;
+	margin-bottom: 8px;
+}
+
+.audio-panel-empty {
+	font-size: 13px;
+	color: var(--text-secondary);
+}
+
+.audio-row {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 8px 0;
+	border-top: 1px solid var(--border);
+}
+
+.audio-name {
+	font-size: 13px;
+	font-weight: 600;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.audio-slider-row {
+	display: grid;
+	grid-template-columns: 56px minmax(0, 1fr) auto;
+	gap: 8px;
+	align-items: center;
+}
+
+.audio-slider-row button {
+	height: 30px;
+	border: none;
+	border-radius: 8px;
+	padding: 0 10px;
+	background: var(--bg-hover);
+	color: var(--text-primary);
+	cursor: pointer;
+}
+
 .control-button {
 	min-width: 40px;
 	width: auto;

--- a/src/components/CallUi/CallUi.module.css
+++ b/src/components/CallUi/CallUi.module.css
@@ -451,6 +451,34 @@
 	border-top: 1px solid var(--border);
 }
 
+.audio-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.audio-avatar {
+	width: 24px;
+	height: 24px;
+	border-radius: 999px;
+	background: var(--bg-hover);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 12px;
+	font-weight: 700;
+	color: var(--text-primary);
+	overflow: hidden;
+	flex-shrink: 0;
+}
+
+.audio-avatar-image {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
 .audio-name {
 	font-size: 13px;
 	font-weight: 600;
@@ -461,19 +489,54 @@
 
 .audio-slider-row {
 	display: grid;
-	grid-template-columns: 56px minmax(0, 1fr) auto;
+	grid-template-columns: 74px minmax(0, 1fr) 46px 32px;
 	gap: 8px;
 	align-items: center;
 }
 
-.audio-slider-row button {
+.audio-source-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.audio-slider-row input[type="range"] {
+	width: 100%;
+}
+
+.audio-slider-row input[type="range"]:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+.audio-percent {
+	text-align: right;
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.audio-reset {
 	height: 30px;
 	border: none;
 	border-radius: 8px;
-	padding: 0 10px;
+	padding: 0;
 	background: var(--bg-hover);
 	color: var(--text-primary);
 	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.audio-reset:hover {
+	background: var(--bg-active);
+}
+
+.audio-reset:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
 }
 
 .control-button {

--- a/src/components/CallUi/CallUi.tsx
+++ b/src/components/CallUi/CallUi.tsx
@@ -6,13 +6,14 @@ import {
 	VideoTrack,
 	type TrackReference,
 } from "@livekit/components-react";
+import { Mic, MonitorUp, RotateCcw } from "lucide-react";
 import styles from "./CallUi.module.css";
 import { RemoteTrackPublication, Track } from "livekit-client";
 import { useDispatch, useSelector } from "react-redux";
 import type { AppDispatch, RootState } from "../../store/store";
 import { callActions } from "../../store/slices/call.slice";
 import { deviceActions } from "../../store/slices/device.slice";
-import { useEffect, useMemo, useState, type MouseEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { CallParticipantTile } from "./CallParticipantTile";
 import { MicrophoneToggleButton } from "./MicrophoneToggleButton";
 import {
@@ -26,24 +27,6 @@ import {
 } from "../../utils/callQuality";
 import type { CallUiProps } from "./CallUi.props";
 import type { UserMini } from "../../entities/UserMini";
-import { AudioMixPanel } from "./AudioMixPanel/AudioMixPanel";
-import { ParticipantContextMenu } from "./ParticipantContextMenu/ParticipantContextMenu";
-import { useDismissibleLayer } from "../../hooks/useDismissibleLayer";
-import { UserProfilePopover } from "./UserProfilePopover/UserProfilePopover";
-import { StringToColor } from "../../utils/stringHelpers";
-import { TheaterModeView } from "./TheaterMode/TheaterModeView";
-
-interface ParticipantMenuState {
-	x: number;
-	y: number;
-	participantIdentity: string;
-}
-
-interface ProfilePopoverState {
-	x: number;
-	y: number;
-	participantIdentity: string;
-}
 
 export function CallUi({
 	hasChat,
@@ -55,8 +38,6 @@ export function CallUi({
 }: CallUiProps) {
 	const [hadRemoteParticipant, setHadRemoteParticipant] = useState(false);
 	const [isAudioPanelOpen, setIsAudioPanelOpen] = useState(false);
-	const [participantMenu, setParticipantMenu] = useState<ParticipantMenuState | null>(null);
-	const [profilePopover, setProfilePopover] = useState<ProfilePopoverState | null>(null);
 
 	const dispatch = useDispatch<AppDispatch>();
 
@@ -403,25 +384,6 @@ export function CallUi({
 		return () => dispatch(callActions.setSelectedScreenTrackSid(trackSid));
 	};
 
-	const getOpenParticipantContextMenuHandler =
-		(participantIdentity: string) => (event: MouseEvent<HTMLButtonElement>) => {
-			event.preventDefault();
-			event.stopPropagation();
-
-			const menuWidth = 340;
-			const menuHeight = 320;
-
-			let x = event.clientX;
-			let y = event.clientY;
-			if (x + menuWidth > window.innerWidth) x = window.innerWidth - menuWidth - 8;
-			if (y + menuHeight > window.innerHeight) y = window.innerHeight - menuHeight - 8;
-			if (x < 8) x = 8;
-			if (y < 8) y = 8;
-
-			setProfilePopover(null);
-			setParticipantMenu({ x, y, participantIdentity });
-		};
-
 	const getVolumeValue = (
 		participantIdentity: string,
 		source: "microphone" | "screenShareAudio"
@@ -434,62 +396,9 @@ export function CallUi({
 	const hasAnyRemoteAudioTracks =
 		remoteMicrophoneParticipants.size > 0 || remoteScreenAudioParticipants.size > 0;
 
-	const currentMenuParticipant = useMemo(
-		() =>
-			participantMenu
-				? sortedParticipants.find(
-						(participant) => participant.identity === participantMenu.participantIdentity
-				  ) ?? null
-				: null,
-		[participantMenu, sortedParticipants]
-	);
-
-	const currentMenuParticipantCard = useMemo(
-		() =>
-			currentMenuParticipant
-				? participantCardByIdentity.get(currentMenuParticipant.identity) ?? null
-				: null,
-		[currentMenuParticipant, participantCardByIdentity]
-	);
-
-	useDismissibleLayer({
-		isOpen: Boolean(participantMenu),
-		onDismiss: () => setParticipantMenu(null),
-	});
-
-	useDismissibleLayer({
-		isOpen: Boolean(profilePopover),
-		onDismiss: () => setProfilePopover(null),
-	});
-
-	useEffect(() => {
-		if (!call.isTheaterMode) return;
-
-		const onEscape = (event: KeyboardEvent) => {
-			if (event.key === "Escape") {
-				dispatch(callActions.setTheaterMode(false));
-			}
-		};
-
-		window.addEventListener("keydown", onEscape);
-		return () => window.removeEventListener("keydown", onEscape);
-	}, [call.isTheaterMode, dispatch]);
-
-	useEffect(() => {
-		if (!call.isTheaterMode) return;
-		if (mainScreenTrack) return;
-		dispatch(callActions.setTheaterMode(false));
-	}, [call.isTheaterMode, mainScreenTrack, dispatch]);
-
 	return (
 		<div className={styles["call-root"]}>
-			{call.isTheaterMode && hasScreenShare && mainScreenTrack ? (
-				<TheaterModeView
-					trackRef={mainScreenTrack}
-					displayName={mainScreenTrack.participant.name || mainScreenTrack.participant.identity}
-					onExit={() => dispatch(callActions.setTheaterMode(false))}
-				/>
-			) : hasScreenShare && mainScreenTrack ? (
+			{hasScreenShare && mainScreenTrack ? (
 				<div className={styles["screen-layout"]}>
 					<div className={styles["main-screen"]}>
 						{mainScreenTrack.participant.isLocal ||
@@ -525,7 +434,6 @@ export function CallUi({
 										call.selectedScreenTrackSid
 									}
 									onOpenScreenShare={getOpenScreenShareHandler(screenTrack)}
-									onContextMenu={getOpenParticipantContextMenuHandler(participant.identity)}
 								/>
 							)
 						)}
@@ -547,7 +455,6 @@ export function CallUi({
 									call.selectedScreenTrackSid
 								}
 								onOpenScreenShare={getOpenScreenShareHandler(screenTrack)}
-								onContextMenu={getOpenParticipantContextMenuHandler(participant.identity)}
 							/>
 						)
 					)}
@@ -568,7 +475,6 @@ export function CallUi({
 									call.selectedScreenTrackSid
 								}
 								onOpenScreenShare={getOpenScreenShareHandler(screenTrack)}
-								onContextMenu={getOpenParticipantContextMenuHandler(participant.identity)}
 							/>
 						)
 					)}
@@ -585,59 +491,127 @@ export function CallUi({
 			)}
 
 			{isAudioPanelOpen && (
-				<AudioMixPanel
-					participants={sortedParticipants
-						.filter((participant) => !participant.isLocal)
-						.map((participant) => {
-							const card = participantCardByIdentity.get(participant.identity);
-							const displayName = card?.displayName || participant.identity;
-							return {
-								identity: participant.identity,
-								displayName,
-								avatarUrl: card?.avatarUrl ?? null,
-								avatarLabel: displayName.slice(0, 1).toUpperCase(),
-								micAvailable: remoteMicrophoneParticipants.has(participant.identity),
-								streamAvailable: remoteScreenAudioParticipants.has(participant.identity),
-								micVolume: getVolumeValue(participant.identity, "microphone"),
-								streamVolume: getVolumeValue(participant.identity, "screenShareAudio"),
-							};
-						})}
-					hasAnyRemoteAudioTracks={hasAnyRemoteAudioTracks}
-					onMicVolumeChange={(participantIdentity, value) =>
-						dispatch(
-							deviceActions.setParticipantVolume({
-								participantIdentity,
-								source: "microphone",
-								volume: value,
+				<div className={styles["audio-panel"]}>
+					<div className={styles["audio-panel-title"]}>Participant volume</div>
+					{sortedParticipants.filter((participant) => !participant.isLocal).length === 0 ? (
+						<div className={styles["audio-panel-empty"]}>No remote participants yet.</div>
+					) : !hasAnyRemoteAudioTracks ? (
+						<div className={styles["audio-panel-empty"]}>
+							Remote audio tracks are not available yet.
+						</div>
+					) : (
+						sortedParticipants
+							.filter((participant) => !participant.isLocal)
+							.map((participant) => {
+								const micAvailable = remoteMicrophoneParticipants.has(participant.identity);
+								const streamAvailable = remoteScreenAudioParticipants.has(participant.identity);
+								const micVolume = getVolumeValue(participant.identity, "microphone");
+								const streamVolume = getVolumeValue(participant.identity, "screenShareAudio");
+								const card = participantCardByIdentity.get(participant.identity);
+								const displayName = card?.displayName || participant.identity;
+								const avatarLabel = displayName.slice(0, 1).toUpperCase();
+
+								return (
+									<div key={participant.identity} className={styles["audio-row"]}>
+										<div className={styles["audio-header"]}>
+											<div className={styles["audio-avatar"]}>
+												{card?.avatarUrl ? (
+													<img
+														src={card.avatarUrl}
+														crossOrigin="anonymous"
+														alt={`${displayName} avatar`}
+														className={styles["audio-avatar-image"]}
+													/>
+												) : (
+													<span>{avatarLabel}</span>
+												)}
+											</div>
+											<div className={styles["audio-name"]} title={displayName}>
+												{displayName}
+											</div>
+										</div>
+										<div className={styles["audio-slider-row"]}>
+											<div className={styles["audio-source-label"]}>
+												<Mic size={14} />
+												<span>Mic</span>
+											</div>
+											<input
+												type="range"
+												min={0}
+												max={100}
+												value={micVolume}
+												disabled={!micAvailable}
+												onChange={(event) =>
+													dispatch(
+														deviceActions.setParticipantVolume({
+															participantIdentity: participant.identity,
+															source: "microphone",
+															volume: Number(event.target.value),
+														})
+													)
+												}
+											/>
+											<span className={styles["audio-percent"]}>{micVolume}%</span>
+											<button
+												type="button"
+												className={styles["audio-reset"]}
+												title="Reset to 100%"
+												onClick={() =>
+													dispatch(
+														deviceActions.resetParticipantVolume({
+															participantIdentity: participant.identity,
+															source: "microphone",
+														})
+													)
+												}
+											>
+												<RotateCcw size={13} />
+											</button>
+										</div>
+										{streamAvailable && (
+											<div className={styles["audio-slider-row"]}>
+												<div className={styles["audio-source-label"]}>
+													<MonitorUp size={14} />
+													<span>Stream</span>
+												</div>
+												<input
+													type="range"
+													min={0}
+													max={100}
+													value={streamVolume}
+													onChange={(event) =>
+														dispatch(
+															deviceActions.setParticipantVolume({
+																participantIdentity: participant.identity,
+																source: "screenShareAudio",
+																volume: Number(event.target.value),
+															})
+														)
+													}
+												/>
+												<span className={styles["audio-percent"]}>{streamVolume}%</span>
+												<button
+													type="button"
+													className={styles["audio-reset"]}
+													title="Reset to 100%"
+													onClick={() =>
+														dispatch(
+															deviceActions.resetParticipantVolume({
+																participantIdentity: participant.identity,
+																source: "screenShareAudio",
+															})
+														)
+													}
+												>
+													<RotateCcw size={13} />
+												</button>
+											</div>
+										)}
+									</div>
+								);
 							})
-						)
-					}
-					onMicReset={(participantIdentity) =>
-						dispatch(
-							deviceActions.resetParticipantVolume({
-								participantIdentity,
-								source: "microphone",
-							})
-						)
-					}
-					onStreamVolumeChange={(participantIdentity, value) =>
-						dispatch(
-							deviceActions.setParticipantVolume({
-								participantIdentity,
-								source: "screenShareAudio",
-								volume: value,
-							})
-						)
-					}
-					onStreamReset={(participantIdentity) =>
-						dispatch(
-							deviceActions.resetParticipantVolume({
-								participantIdentity,
-								source: "screenShareAudio",
-							})
-						)
-					}
-				/>
+					)}
+				</div>
 			)}
 
 			<div className={styles["controls-bar"]}>
@@ -683,17 +657,6 @@ export function CallUi({
 					{isAudioPanelOpen ? "Close Mix" : "Audio Mix"}
 				</button>
 
-				{hasScreenShare && (
-					<button
-						type="button"
-						className={styles["control-button"]}
-						onClick={() => dispatch(callActions.setTheaterMode(!call.isTheaterMode))}
-						title="Toggle theater mode"
-					>
-						{call.isTheaterMode ? "Exit Theater" : "Theater"}
-					</button>
-				)}
-
 				<button
 					type="button"
 					className={styles["control-button"]}
@@ -725,105 +688,6 @@ export function CallUi({
 					<img src="/leave-call-icon.svg" alt="Leave call" />
 				</button>
 			</div>
-
-			{participantMenu && currentMenuParticipant && currentMenuParticipantCard && (
-				<div onClick={() => setParticipantMenu(null)}>
-					<ParticipantContextMenu
-						x={participantMenu.x}
-						y={participantMenu.y}
-						displayName={currentMenuParticipantCard.displayName}
-						hasScreenShare={Boolean(screenTrackByParticipant.get(currentMenuParticipant.identity))}
-						hasScreenShareAudio={remoteScreenAudioParticipants.has(currentMenuParticipant.identity)}
-						micVolume={getVolumeValue(currentMenuParticipant.identity, "microphone")}
-						streamVolume={getVolumeValue(currentMenuParticipant.identity, "screenShareAudio")}
-						onOpenProfile={() => {
-							setParticipantMenu(null);
-							const popoverWidth = 360;
-							const popoverHeight = 420;
-							let x = participantMenu.x;
-							let y = participantMenu.y;
-							if (x + popoverWidth > window.innerWidth) x = window.innerWidth - popoverWidth - 8;
-							if (y + popoverHeight > window.innerHeight) y = window.innerHeight - popoverHeight - 8;
-							if (x < 8) x = 8;
-							if (y < 8) y = 8;
-							setProfilePopover({
-								x,
-								y,
-								participantIdentity: currentMenuParticipant.identity,
-							});
-						}}
-						onOpenScreenShare={() => {
-							setParticipantMenu(null);
-							const trackRef = screenTrackByParticipant.get(currentMenuParticipant.identity);
-							const sid = trackRef?.publication?.trackSid;
-							if (sid) {
-								dispatch(callActions.setSelectedScreenTrackSid(sid));
-							}
-						}}
-						onOpenTheater={() => {
-							const trackRef = screenTrackByParticipant.get(currentMenuParticipant.identity);
-							const sid = trackRef?.publication?.trackSid;
-							if (sid) {
-								dispatch(callActions.setSelectedScreenTrackSid(sid));
-								dispatch(callActions.setTheaterMode(true));
-							}
-							setParticipantMenu(null);
-						}}
-						onMicChange={(value) =>
-							dispatch(
-								deviceActions.setParticipantVolume({
-									participantIdentity: currentMenuParticipant.identity,
-									source: "microphone",
-									volume: value,
-								})
-							)
-						}
-						onMicReset={() =>
-							dispatch(
-								deviceActions.resetParticipantVolume({
-									participantIdentity: currentMenuParticipant.identity,
-									source: "microphone",
-								})
-							)
-						}
-						onStreamChange={(value) =>
-							dispatch(
-								deviceActions.setParticipantVolume({
-									participantIdentity: currentMenuParticipant.identity,
-									source: "screenShareAudio",
-									volume: value,
-								})
-							)
-						}
-						onStreamReset={() =>
-							dispatch(
-								deviceActions.resetParticipantVolume({
-									participantIdentity: currentMenuParticipant.identity,
-									source: "screenShareAudio",
-								})
-							)
-						}
-					/>
-				</div>
-			)}
-
-			{profilePopover && (
-				<div onClick={() => setProfilePopover(null)}>
-					<UserProfilePopover
-						x={profilePopover.x}
-						y={profilePopover.y}
-						displayName={
-							participantCardByIdentity.get(profilePopover.participantIdentity)?.displayName ??
-							profilePopover.participantIdentity
-						}
-						avatarUrl={
-							participantCardByIdentity.get(profilePopover.participantIdentity)?.avatarUrl ??
-							null
-						}
-						avatarBg={StringToColor(profilePopover.participantIdentity)}
-					/>
-				</div>
-			)}
 		</div>
 	);
 }

--- a/src/components/CallUi/CallUi.tsx
+++ b/src/components/CallUi/CallUi.tsx
@@ -6,14 +6,13 @@ import {
 	VideoTrack,
 	type TrackReference,
 } from "@livekit/components-react";
-import { Mic, MonitorUp, RotateCcw } from "lucide-react";
 import styles from "./CallUi.module.css";
 import { RemoteTrackPublication, Track } from "livekit-client";
 import { useDispatch, useSelector } from "react-redux";
 import type { AppDispatch, RootState } from "../../store/store";
 import { callActions } from "../../store/slices/call.slice";
 import { deviceActions } from "../../store/slices/device.slice";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type MouseEvent } from "react";
 import { CallParticipantTile } from "./CallParticipantTile";
 import { MicrophoneToggleButton } from "./MicrophoneToggleButton";
 import {
@@ -27,6 +26,24 @@ import {
 } from "../../utils/callQuality";
 import type { CallUiProps } from "./CallUi.props";
 import type { UserMini } from "../../entities/UserMini";
+import { AudioMixPanel } from "./AudioMixPanel/AudioMixPanel";
+import { ParticipantContextMenu } from "./ParticipantContextMenu/ParticipantContextMenu";
+import { useDismissibleLayer } from "../../hooks/useDismissibleLayer";
+import { UserProfilePopover } from "./UserProfilePopover/UserProfilePopover";
+import { StringToColor } from "../../utils/stringHelpers";
+import { TheaterModeView } from "./TheaterMode/TheaterModeView";
+
+interface ParticipantMenuState {
+	x: number;
+	y: number;
+	participantIdentity: string;
+}
+
+interface ProfilePopoverState {
+	x: number;
+	y: number;
+	participantIdentity: string;
+}
 
 export function CallUi({
 	hasChat,
@@ -38,6 +55,8 @@ export function CallUi({
 }: CallUiProps) {
 	const [hadRemoteParticipant, setHadRemoteParticipant] = useState(false);
 	const [isAudioPanelOpen, setIsAudioPanelOpen] = useState(false);
+	const [participantMenu, setParticipantMenu] = useState<ParticipantMenuState | null>(null);
+	const [profilePopover, setProfilePopover] = useState<ProfilePopoverState | null>(null);
 
 	const dispatch = useDispatch<AppDispatch>();
 
@@ -384,6 +403,25 @@ export function CallUi({
 		return () => dispatch(callActions.setSelectedScreenTrackSid(trackSid));
 	};
 
+	const getOpenParticipantContextMenuHandler =
+		(participantIdentity: string) => (event: MouseEvent<HTMLButtonElement>) => {
+			event.preventDefault();
+			event.stopPropagation();
+
+			const menuWidth = 340;
+			const menuHeight = 320;
+
+			let x = event.clientX;
+			let y = event.clientY;
+			if (x + menuWidth > window.innerWidth) x = window.innerWidth - menuWidth - 8;
+			if (y + menuHeight > window.innerHeight) y = window.innerHeight - menuHeight - 8;
+			if (x < 8) x = 8;
+			if (y < 8) y = 8;
+
+			setProfilePopover(null);
+			setParticipantMenu({ x, y, participantIdentity });
+		};
+
 	const getVolumeValue = (
 		participantIdentity: string,
 		source: "microphone" | "screenShareAudio"
@@ -396,9 +434,62 @@ export function CallUi({
 	const hasAnyRemoteAudioTracks =
 		remoteMicrophoneParticipants.size > 0 || remoteScreenAudioParticipants.size > 0;
 
+	const currentMenuParticipant = useMemo(
+		() =>
+			participantMenu
+				? sortedParticipants.find(
+						(participant) => participant.identity === participantMenu.participantIdentity
+				  ) ?? null
+				: null,
+		[participantMenu, sortedParticipants]
+	);
+
+	const currentMenuParticipantCard = useMemo(
+		() =>
+			currentMenuParticipant
+				? participantCardByIdentity.get(currentMenuParticipant.identity) ?? null
+				: null,
+		[currentMenuParticipant, participantCardByIdentity]
+	);
+
+	useDismissibleLayer({
+		isOpen: Boolean(participantMenu),
+		onDismiss: () => setParticipantMenu(null),
+	});
+
+	useDismissibleLayer({
+		isOpen: Boolean(profilePopover),
+		onDismiss: () => setProfilePopover(null),
+	});
+
+	useEffect(() => {
+		if (!call.isTheaterMode) return;
+
+		const onEscape = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				dispatch(callActions.setTheaterMode(false));
+			}
+		};
+
+		window.addEventListener("keydown", onEscape);
+		return () => window.removeEventListener("keydown", onEscape);
+	}, [call.isTheaterMode, dispatch]);
+
+	useEffect(() => {
+		if (!call.isTheaterMode) return;
+		if (mainScreenTrack) return;
+		dispatch(callActions.setTheaterMode(false));
+	}, [call.isTheaterMode, mainScreenTrack, dispatch]);
+
 	return (
 		<div className={styles["call-root"]}>
-			{hasScreenShare && mainScreenTrack ? (
+			{call.isTheaterMode && hasScreenShare && mainScreenTrack ? (
+				<TheaterModeView
+					trackRef={mainScreenTrack}
+					displayName={mainScreenTrack.participant.name || mainScreenTrack.participant.identity}
+					onExit={() => dispatch(callActions.setTheaterMode(false))}
+				/>
+			) : hasScreenShare && mainScreenTrack ? (
 				<div className={styles["screen-layout"]}>
 					<div className={styles["main-screen"]}>
 						{mainScreenTrack.participant.isLocal ||
@@ -434,6 +525,7 @@ export function CallUi({
 										call.selectedScreenTrackSid
 									}
 									onOpenScreenShare={getOpenScreenShareHandler(screenTrack)}
+									onContextMenu={getOpenParticipantContextMenuHandler(participant.identity)}
 								/>
 							)
 						)}
@@ -455,6 +547,7 @@ export function CallUi({
 									call.selectedScreenTrackSid
 								}
 								onOpenScreenShare={getOpenScreenShareHandler(screenTrack)}
+								onContextMenu={getOpenParticipantContextMenuHandler(participant.identity)}
 							/>
 						)
 					)}
@@ -475,6 +568,7 @@ export function CallUi({
 									call.selectedScreenTrackSid
 								}
 								onOpenScreenShare={getOpenScreenShareHandler(screenTrack)}
+								onContextMenu={getOpenParticipantContextMenuHandler(participant.identity)}
 							/>
 						)
 					)}
@@ -491,126 +585,59 @@ export function CallUi({
 			)}
 
 			{isAudioPanelOpen && (
-				<div className={styles["audio-panel"]}>
-					<div className={styles["audio-panel-title"]}>Participant volume</div>
-					{sortedParticipants.filter((participant) => !participant.isLocal).length === 0 ? (
-						<div className={styles["audio-panel-empty"]}>No remote participants yet.</div>
-					) : !hasAnyRemoteAudioTracks ? (
-						<div className={styles["audio-panel-empty"]}>
-							Remote audio tracks are not available yet.
-						</div>
-					) : (
-						sortedParticipants
-							.filter((participant) => !participant.isLocal)
-							.map((participant) => {
-								const micAvailable = remoteMicrophoneParticipants.has(participant.identity);
-								const streamAvailable = remoteScreenAudioParticipants.has(participant.identity);
-								const micVolume = getVolumeValue(participant.identity, "microphone");
-								const streamVolume = getVolumeValue(participant.identity, "screenShareAudio");
-								const card = participantCardByIdentity.get(participant.identity);
-								const displayName = card?.displayName || participant.identity;
-								const avatarLabel = displayName.slice(0, 1).toUpperCase();
-
-								return (
-									<div key={participant.identity} className={styles["audio-row"]}>
-										<div className={styles["audio-header"]}>
-											<div className={styles["audio-avatar"]}>
-												{card?.avatarUrl ? (
-													<img
-														src={card.avatarUrl}
-														alt={`${displayName} avatar`}
-														className={styles["audio-avatar-image"]}
-													/>
-												) : (
-													<span>{avatarLabel}</span>
-												)}
-											</div>
-											<div className={styles["audio-name"]} title={displayName}>
-												{displayName}
-											</div>
-										</div>
-										<div className={styles["audio-slider-row"]}>
-											<div className={styles["audio-source-label"]}>
-												<Mic size={14} />
-												<span>Mic</span>
-											</div>
-											<input
-												type="range"
-												min={0}
-												max={100}
-												value={micVolume}
-												disabled={!micAvailable}
-												onChange={(event) =>
-													dispatch(
-														deviceActions.setParticipantVolume({
-															participantIdentity: participant.identity,
-															source: "microphone",
-															volume: Number(event.target.value),
-														})
-													)
-												}
-											/>
-											<span className={styles["audio-percent"]}>{micVolume}%</span>
-											<button
-												type="button"
-												className={styles["audio-reset"]}
-												title="Reset to 100%"
-												onClick={() =>
-													dispatch(
-														deviceActions.resetParticipantVolume({
-															participantIdentity: participant.identity,
-															source: "microphone",
-														})
-													)
-												}
-											>
-												<RotateCcw size={13} />
-											</button>
-										</div>
-										{streamAvailable && (
-											<div className={styles["audio-slider-row"]}>
-												<div className={styles["audio-source-label"]}>
-													<MonitorUp size={14} />
-													<span>Stream</span>
-												</div>
-												<input
-													type="range"
-													min={0}
-													max={100}
-													value={streamVolume}
-													onChange={(event) =>
-														dispatch(
-															deviceActions.setParticipantVolume({
-																participantIdentity: participant.identity,
-																source: "screenShareAudio",
-																volume: Number(event.target.value),
-															})
-														)
-													}
-												/>
-												<span className={styles["audio-percent"]}>{streamVolume}%</span>
-												<button
-													type="button"
-													className={styles["audio-reset"]}
-													title="Reset to 100%"
-													onClick={() =>
-														dispatch(
-															deviceActions.resetParticipantVolume({
-																participantIdentity: participant.identity,
-																source: "screenShareAudio",
-															})
-														)
-													}
-												>
-													<RotateCcw size={13} />
-												</button>
-											</div>
-										)}
-									</div>
-								);
+				<AudioMixPanel
+					participants={sortedParticipants
+						.filter((participant) => !participant.isLocal)
+						.map((participant) => {
+							const card = participantCardByIdentity.get(participant.identity);
+							const displayName = card?.displayName || participant.identity;
+							return {
+								identity: participant.identity,
+								displayName,
+								avatarUrl: card?.avatarUrl ?? null,
+								avatarLabel: displayName.slice(0, 1).toUpperCase(),
+								micAvailable: remoteMicrophoneParticipants.has(participant.identity),
+								streamAvailable: remoteScreenAudioParticipants.has(participant.identity),
+								micVolume: getVolumeValue(participant.identity, "microphone"),
+								streamVolume: getVolumeValue(participant.identity, "screenShareAudio"),
+							};
+						})}
+					hasAnyRemoteAudioTracks={hasAnyRemoteAudioTracks}
+					onMicVolumeChange={(participantIdentity, value) =>
+						dispatch(
+							deviceActions.setParticipantVolume({
+								participantIdentity,
+								source: "microphone",
+								volume: value,
 							})
-					)}
-				</div>
+						)
+					}
+					onMicReset={(participantIdentity) =>
+						dispatch(
+							deviceActions.resetParticipantVolume({
+								participantIdentity,
+								source: "microphone",
+							})
+						)
+					}
+					onStreamVolumeChange={(participantIdentity, value) =>
+						dispatch(
+							deviceActions.setParticipantVolume({
+								participantIdentity,
+								source: "screenShareAudio",
+								volume: value,
+							})
+						)
+					}
+					onStreamReset={(participantIdentity) =>
+						dispatch(
+							deviceActions.resetParticipantVolume({
+								participantIdentity,
+								source: "screenShareAudio",
+							})
+						)
+					}
+				/>
 			)}
 
 			<div className={styles["controls-bar"]}>
@@ -656,6 +683,17 @@ export function CallUi({
 					{isAudioPanelOpen ? "Close Mix" : "Audio Mix"}
 				</button>
 
+				{hasScreenShare && (
+					<button
+						type="button"
+						className={styles["control-button"]}
+						onClick={() => dispatch(callActions.setTheaterMode(!call.isTheaterMode))}
+						title="Toggle theater mode"
+					>
+						{call.isTheaterMode ? "Exit Theater" : "Theater"}
+					</button>
+				)}
+
 				<button
 					type="button"
 					className={styles["control-button"]}
@@ -687,6 +725,105 @@ export function CallUi({
 					<img src="/leave-call-icon.svg" alt="Leave call" />
 				</button>
 			</div>
+
+			{participantMenu && currentMenuParticipant && currentMenuParticipantCard && (
+				<div onClick={() => setParticipantMenu(null)}>
+					<ParticipantContextMenu
+						x={participantMenu.x}
+						y={participantMenu.y}
+						displayName={currentMenuParticipantCard.displayName}
+						hasScreenShare={Boolean(screenTrackByParticipant.get(currentMenuParticipant.identity))}
+						hasScreenShareAudio={remoteScreenAudioParticipants.has(currentMenuParticipant.identity)}
+						micVolume={getVolumeValue(currentMenuParticipant.identity, "microphone")}
+						streamVolume={getVolumeValue(currentMenuParticipant.identity, "screenShareAudio")}
+						onOpenProfile={() => {
+							setParticipantMenu(null);
+							const popoverWidth = 360;
+							const popoverHeight = 420;
+							let x = participantMenu.x;
+							let y = participantMenu.y;
+							if (x + popoverWidth > window.innerWidth) x = window.innerWidth - popoverWidth - 8;
+							if (y + popoverHeight > window.innerHeight) y = window.innerHeight - popoverHeight - 8;
+							if (x < 8) x = 8;
+							if (y < 8) y = 8;
+							setProfilePopover({
+								x,
+								y,
+								participantIdentity: currentMenuParticipant.identity,
+							});
+						}}
+						onOpenScreenShare={() => {
+							setParticipantMenu(null);
+							const trackRef = screenTrackByParticipant.get(currentMenuParticipant.identity);
+							const sid = trackRef?.publication?.trackSid;
+							if (sid) {
+								dispatch(callActions.setSelectedScreenTrackSid(sid));
+							}
+						}}
+						onOpenTheater={() => {
+							const trackRef = screenTrackByParticipant.get(currentMenuParticipant.identity);
+							const sid = trackRef?.publication?.trackSid;
+							if (sid) {
+								dispatch(callActions.setSelectedScreenTrackSid(sid));
+								dispatch(callActions.setTheaterMode(true));
+							}
+							setParticipantMenu(null);
+						}}
+						onMicChange={(value) =>
+							dispatch(
+								deviceActions.setParticipantVolume({
+									participantIdentity: currentMenuParticipant.identity,
+									source: "microphone",
+									volume: value,
+								})
+							)
+						}
+						onMicReset={() =>
+							dispatch(
+								deviceActions.resetParticipantVolume({
+									participantIdentity: currentMenuParticipant.identity,
+									source: "microphone",
+								})
+							)
+						}
+						onStreamChange={(value) =>
+							dispatch(
+								deviceActions.setParticipantVolume({
+									participantIdentity: currentMenuParticipant.identity,
+									source: "screenShareAudio",
+									volume: value,
+								})
+							)
+						}
+						onStreamReset={() =>
+							dispatch(
+								deviceActions.resetParticipantVolume({
+									participantIdentity: currentMenuParticipant.identity,
+									source: "screenShareAudio",
+								})
+							)
+						}
+					/>
+				</div>
+			)}
+
+			{profilePopover && (
+				<div onClick={() => setProfilePopover(null)}>
+					<UserProfilePopover
+						x={profilePopover.x}
+						y={profilePopover.y}
+						displayName={
+							participantCardByIdentity.get(profilePopover.participantIdentity)?.displayName ??
+							profilePopover.participantIdentity
+						}
+						avatarUrl={
+							participantCardByIdentity.get(profilePopover.participantIdentity)?.avatarUrl ??
+							null
+						}
+						avatarBg={StringToColor(profilePopover.participantIdentity)}
+					/>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/CallUi/CallUi.tsx
+++ b/src/components/CallUi/CallUi.tsx
@@ -6,6 +6,7 @@ import {
 	VideoTrack,
 	type TrackReference,
 } from "@livekit/components-react";
+import { Mic, MonitorUp, RotateCcw } from "lucide-react";
 import styles from "./CallUi.module.css";
 import { RemoteTrackPublication, Track } from "livekit-client";
 import { useDispatch, useSelector } from "react-redux";
@@ -241,6 +242,20 @@ export function CallUi({
 		]
 	);
 
+	const participantCardByIdentity = useMemo(() => {
+		const map = new Map<
+			string,
+			{ avatarUrl: string | null; displayName: string }
+		>();
+		participantCards.forEach(({ participant, avatarUrl }) => {
+			map.set(participant.identity, {
+				avatarUrl,
+				displayName: participant.name || participant.identity,
+			});
+		});
+		return map;
+	}, [participantCards]);
+
 	const remoteParticipantsCount = useMemo(
 		() => sortedParticipants.filter((participant) => !participant.isLocal).length,
 		[sortedParticipants]
@@ -378,6 +393,9 @@ export function CallUi({
 				item.participantIdentity === participantIdentity && item.source === source
 		)?.volume ?? 100;
 
+	const hasAnyRemoteAudioTracks =
+		remoteMicrophoneParticipants.size > 0 || remoteScreenAudioParticipants.size > 0;
+
 	return (
 		<div className={styles["call-root"]}>
 			{hasScreenShare && mainScreenTrack ? (
@@ -477,6 +495,10 @@ export function CallUi({
 					<div className={styles["audio-panel-title"]}>Participant volume</div>
 					{sortedParticipants.filter((participant) => !participant.isLocal).length === 0 ? (
 						<div className={styles["audio-panel-empty"]}>No remote participants yet.</div>
+					) : !hasAnyRemoteAudioTracks ? (
+						<div className={styles["audio-panel-empty"]}>
+							Remote audio tracks are not available yet.
+						</div>
 					) : (
 						sortedParticipants
 							.filter((participant) => !participant.isLocal)
@@ -485,14 +507,33 @@ export function CallUi({
 								const streamAvailable = remoteScreenAudioParticipants.has(participant.identity);
 								const micVolume = getVolumeValue(participant.identity, "microphone");
 								const streamVolume = getVolumeValue(participant.identity, "screenShareAudio");
+								const card = participantCardByIdentity.get(participant.identity);
+								const displayName = card?.displayName || participant.identity;
+								const avatarLabel = displayName.slice(0, 1).toUpperCase();
 
 								return (
 									<div key={participant.identity} className={styles["audio-row"]}>
-										<div className={styles["audio-name"]}>
-											{participant.name || participant.identity}
+										<div className={styles["audio-header"]}>
+											<div className={styles["audio-avatar"]}>
+												{card?.avatarUrl ? (
+													<img
+														src={card.avatarUrl}
+														alt={`${displayName} avatar`}
+														className={styles["audio-avatar-image"]}
+													/>
+												) : (
+													<span>{avatarLabel}</span>
+												)}
+											</div>
+											<div className={styles["audio-name"]} title={displayName}>
+												{displayName}
+											</div>
 										</div>
 										<div className={styles["audio-slider-row"]}>
-											<span>Mic</span>
+											<div className={styles["audio-source-label"]}>
+												<Mic size={14} />
+												<span>Mic</span>
+											</div>
 											<input
 												type="range"
 												min={0}
@@ -509,8 +550,11 @@ export function CallUi({
 													)
 												}
 											/>
+											<span className={styles["audio-percent"]}>{micVolume}%</span>
 											<button
 												type="button"
+												className={styles["audio-reset"]}
+												title="Reset to 100%"
 												onClick={() =>
 													dispatch(
 														deviceActions.resetParticipantVolume({
@@ -520,12 +564,15 @@ export function CallUi({
 													)
 												}
 											>
-												Reset
+												<RotateCcw size={13} />
 											</button>
 										</div>
 										{streamAvailable && (
 											<div className={styles["audio-slider-row"]}>
-												<span>Stream</span>
+												<div className={styles["audio-source-label"]}>
+													<MonitorUp size={14} />
+													<span>Stream</span>
+												</div>
 												<input
 													type="range"
 													min={0}
@@ -541,8 +588,11 @@ export function CallUi({
 														)
 													}
 												/>
+												<span className={styles["audio-percent"]}>{streamVolume}%</span>
 												<button
 													type="button"
+													className={styles["audio-reset"]}
+													title="Reset to 100%"
 													onClick={() =>
 														dispatch(
 															deviceActions.resetParticipantVolume({
@@ -552,7 +602,7 @@ export function CallUi({
 														)
 													}
 												>
-													Reset
+													<RotateCcw size={13} />
 												</button>
 											</div>
 										)}

--- a/src/components/CallUi/CallUi.tsx
+++ b/src/components/CallUi/CallUi.tsx
@@ -11,6 +11,7 @@ import { RemoteTrackPublication, Track } from "livekit-client";
 import { useDispatch, useSelector } from "react-redux";
 import type { AppDispatch, RootState } from "../../store/store";
 import { callActions } from "../../store/slices/call.slice";
+import { deviceActions } from "../../store/slices/device.slice";
 import { useEffect, useMemo, useState } from "react";
 import { CallParticipantTile } from "./CallParticipantTile";
 import { MicrophoneToggleButton } from "./MicrophoneToggleButton";
@@ -21,6 +22,7 @@ import {
 	getScreenShareCaptureOptions,
 	getScreenSharePublishOptions,
 	resolveQualitySetting,
+	resolveScreenShareQualitySetting,
 } from "../../utils/callQuality";
 import type { CallUiProps } from "./CallUi.props";
 import type { UserMini } from "../../entities/UserMini";
@@ -34,6 +36,7 @@ export function CallUi({
 	onToggleFocus,
 }: CallUiProps) {
 	const [hadRemoteParticipant, setHadRemoteParticipant] = useState(false);
+	const [isAudioPanelOpen, setIsAudioPanelOpen] = useState(false);
 
 	const dispatch = useDispatch<AppDispatch>();
 
@@ -42,11 +45,15 @@ export function CallUi({
 	const rooms = useSelector((s: RootState) => s.room.rooms);
 	const usersById = useSelector((s: RootState) => s.users.byId);
 	const device = useSelector((s: RootState) => s.device);
+	const participantVolumes = useSelector((s: RootState) => s.device.participantVolumes);
 
 	const participants = useParticipants();
 
 	const videoTracks = useTracks([
 		{ source: Track.Source.Camera, withPlaceholder: false },
+	]);
+	const microphoneAudioTracks = useTracks([
+		{ source: Track.Source.Microphone, withPlaceholder: false },
 	]);
 
 	const screenTracks = useTracks([Track.Source.ScreenShare], {
@@ -163,26 +170,25 @@ export function CallUi({
 		[videoTracks]
 	);
 
-	const isLocalScreenShareActive = useMemo(
-		() =>
-			availableScreenTracks.some(
-				(trackRef) =>
-					trackRef.participant.isLocal &&
-					trackRef.publication
-			),
-		[availableScreenTracks]
-	);
+	const remoteMicrophoneParticipants = useMemo(() => {
+		const participantSet = new Set<string>();
+		microphoneAudioTracks.forEach((trackRef) => {
+			if (trackRef.participant.isLocal) return;
+			if (!trackRef.publication || trackRef.publication.isMuted) return;
+			participantSet.add(trackRef.participant.identity);
+		});
+		return participantSet;
+	}, [microphoneAudioTracks]);
 
-	const hasLocalScreenShareAudio = useMemo(
-		() =>
-			screenAudioTracks.some(
-				(trackRef) =>
-					trackRef.participant.isLocal &&
-					trackRef.publication &&
-					!trackRef.publication.isMuted
-			),
-		[screenAudioTracks]
-	);
+	const remoteScreenAudioParticipants = useMemo(() => {
+		const participantSet = new Set<string>();
+		screenAudioTracks.forEach((trackRef) => {
+			if (trackRef.participant.isLocal) return;
+			if (!trackRef.publication || trackRef.publication.isMuted) return;
+			participantSet.add(trackRef.participant.identity);
+		});
+		return participantSet;
+	}, [screenAudioTracks]);
 
 	const videoTrackByParticipant = useMemo(() => {
 		const trackMap = new Map<string, TrackReference>();
@@ -253,8 +259,7 @@ export function CallUi({
 	}, [device.cameraQuality, qualityRecommendation]);
 
 	const screenSharePreset = useMemo(() => {
-		const quality = resolveQualitySetting(
-			"screenShare",
+		const quality = resolveScreenShareQualitySetting(
 			device.screenShareQuality,
 			qualityRecommendation
 		);
@@ -364,6 +369,15 @@ export function CallUi({
 		return () => dispatch(callActions.setSelectedScreenTrackSid(trackSid));
 	};
 
+	const getVolumeValue = (
+		participantIdentity: string,
+		source: "microphone" | "screenShareAudio"
+	) =>
+		participantVolumes.find(
+			(item) =>
+				item.participantIdentity === participantIdentity && item.source === source
+		)?.volume ?? 100;
+
 	return (
 		<div className={styles["call-root"]}>
 			{hasScreenShare && mainScreenTrack ? (
@@ -458,6 +472,97 @@ export function CallUi({
 				</div>
 			)}
 
+			{isAudioPanelOpen && (
+				<div className={styles["audio-panel"]}>
+					<div className={styles["audio-panel-title"]}>Participant volume</div>
+					{sortedParticipants.filter((participant) => !participant.isLocal).length === 0 ? (
+						<div className={styles["audio-panel-empty"]}>No remote participants yet.</div>
+					) : (
+						sortedParticipants
+							.filter((participant) => !participant.isLocal)
+							.map((participant) => {
+								const micAvailable = remoteMicrophoneParticipants.has(participant.identity);
+								const streamAvailable = remoteScreenAudioParticipants.has(participant.identity);
+								const micVolume = getVolumeValue(participant.identity, "microphone");
+								const streamVolume = getVolumeValue(participant.identity, "screenShareAudio");
+
+								return (
+									<div key={participant.identity} className={styles["audio-row"]}>
+										<div className={styles["audio-name"]}>
+											{participant.name || participant.identity}
+										</div>
+										<div className={styles["audio-slider-row"]}>
+											<span>Mic</span>
+											<input
+												type="range"
+												min={0}
+												max={100}
+												value={micVolume}
+												disabled={!micAvailable}
+												onChange={(event) =>
+													dispatch(
+														deviceActions.setParticipantVolume({
+															participantIdentity: participant.identity,
+															source: "microphone",
+															volume: Number(event.target.value),
+														})
+													)
+												}
+											/>
+											<button
+												type="button"
+												onClick={() =>
+													dispatch(
+														deviceActions.resetParticipantVolume({
+															participantIdentity: participant.identity,
+															source: "microphone",
+														})
+													)
+												}
+											>
+												Reset
+											</button>
+										</div>
+										{streamAvailable && (
+											<div className={styles["audio-slider-row"]}>
+												<span>Stream</span>
+												<input
+													type="range"
+													min={0}
+													max={100}
+													value={streamVolume}
+													onChange={(event) =>
+														dispatch(
+															deviceActions.setParticipantVolume({
+																participantIdentity: participant.identity,
+																source: "screenShareAudio",
+																volume: Number(event.target.value),
+															})
+														)
+													}
+												/>
+												<button
+													type="button"
+													onClick={() =>
+														dispatch(
+															deviceActions.resetParticipantVolume({
+																participantIdentity: participant.identity,
+																source: "screenShareAudio",
+															})
+														)
+													}
+												>
+													Reset
+												</button>
+											</div>
+										)}
+									</div>
+								);
+							})
+					)}
+				</div>
+			)}
+
 			<div className={styles["controls-bar"]}>
 				<MicrophoneToggleButton
 					className={styles["control-button"]}
@@ -478,7 +583,7 @@ export function CallUi({
 					className={styles["control-button"]}
 					captureOptions={screenShareCaptureOptions}
 					publishOptions={screenSharePublishOptions}
-					title="Share screen. Audio is included only when your browser and selected source support it."
+					title="Share screen. Audio is included only when your browser and selected source support it. 1080p120 is experimental and best effort."
 				/>
 
 				{hasChat && (
@@ -491,6 +596,15 @@ export function CallUi({
 						Chat
 					</button>
 				)}
+
+				<button
+					type="button"
+					className={styles["control-button"]}
+					onClick={() => setIsAudioPanelOpen((prev) => !prev)}
+					title="Per-user audio volume controls"
+				>
+					{isAudioPanelOpen ? "Close Mix" : "Audio Mix"}
+				</button>
 
 				<button
 					type="button"

--- a/src/components/CallUi/MicrophoneSettingsSync.tsx
+++ b/src/components/CallUi/MicrophoneSettingsSync.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useRoomContext } from "@livekit/components-react";
+import { useMicrophoneCaptureOptions } from "./useMicrophoneCaptureOptions";
+
+export function MicrophoneSettingsSync() {
+	const room = useRoomContext();
+	const captureOptions = useMicrophoneCaptureOptions();
+	const lastAppliedRef = useRef<string>("");
+
+	const serializedOptions = useMemo(
+		() => JSON.stringify(captureOptions),
+		[captureOptions]
+	);
+
+	useEffect(() => {
+		if (!room.localParticipant.isMicrophoneEnabled) {
+			lastAppliedRef.current = serializedOptions;
+			return;
+		}
+
+		if (lastAppliedRef.current === serializedOptions) return;
+		lastAppliedRef.current = serializedOptions;
+
+		void room.localParticipant
+			.setMicrophoneEnabled(true, captureOptions)
+			.catch((error) => {
+				console.error("Failed to re-apply microphone capture settings", error);
+			});
+	}, [captureOptions, room, serializedOptions]);
+
+	return null;
+}

--- a/src/components/CallUi/ParticipantContextMenu/ParticipantContextMenu.module.css
+++ b/src/components/CallUi/ParticipantContextMenu/ParticipantContextMenu.module.css
@@ -1,0 +1,47 @@
+.menu {
+	position: fixed;
+	z-index: 40;
+	width: 320px;
+	max-width: calc(100vw - 16px);
+	padding: 10px;
+	border-radius: 10px;
+	border: 1px solid var(--border);
+	background: var(--bg-secondary);
+	box-shadow: 0 18px 42px rgba(0, 0, 0, 0.35);
+}
+
+.header {
+	font-size: 13px;
+	font-weight: 700;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-bottom: 8px;
+}
+
+.item {
+	width: 100%;
+	height: 34px;
+	border: none;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--text-primary);
+	text-align: left;
+	padding: 0 8px;
+	cursor: pointer;
+}
+
+.item:hover {
+	background: var(--bg-hover);
+}
+
+.item:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 1px;
+}
+
+.divider {
+	height: 1px;
+	background: var(--border);
+	margin: 8px 0;
+}

--- a/src/components/CallUi/ParticipantContextMenu/ParticipantContextMenu.tsx
+++ b/src/components/CallUi/ParticipantContextMenu/ParticipantContextMenu.tsx
@@ -1,0 +1,70 @@
+import styles from "./ParticipantContextMenu.module.css";
+import { ParticipantVolumeMenu } from "./ParticipantVolumeMenu";
+
+interface ParticipantContextMenuProps {
+	x: number;
+	y: number;
+	displayName: string;
+	hasScreenShare: boolean;
+	hasScreenShareAudio: boolean;
+	micVolume: number;
+	streamVolume: number;
+	onOpenProfile: () => void;
+	onOpenScreenShare: () => void;
+	onOpenTheater: () => void;
+	onMicChange: (value: number) => void;
+	onMicReset: () => void;
+	onStreamChange: (value: number) => void;
+	onStreamReset: () => void;
+}
+
+export function ParticipantContextMenu({
+	x,
+	y,
+	displayName,
+	hasScreenShare,
+	hasScreenShareAudio,
+	micVolume,
+	streamVolume,
+	onOpenProfile,
+	onOpenScreenShare,
+	onOpenTheater,
+	onMicChange,
+	onMicReset,
+	onStreamChange,
+	onStreamReset,
+}: ParticipantContextMenuProps) {
+	return (
+		<div
+			className={styles["menu"]}
+			style={{ top: y, left: x }}
+			role="menu"
+			onClick={(event) => event.stopPropagation()}
+		>
+			<div className={styles["header"]} title={displayName}>{displayName}</div>
+			<button type="button" className={styles["item"]} onClick={onOpenProfile}>
+				Open profile
+			</button>
+			{hasScreenShare && (
+				<>
+					<button type="button" className={styles["item"]} onClick={onOpenScreenShare}>
+						Open screen share
+					</button>
+					<button type="button" className={styles["item"]} onClick={onOpenTheater}>
+						Open theater mode
+					</button>
+				</>
+			)}
+			<div className={styles["divider"]} />
+			<ParticipantVolumeMenu
+				micVolume={micVolume}
+				streamVolume={streamVolume}
+				hasScreenShareAudio={hasScreenShareAudio}
+				onMicChange={onMicChange}
+				onMicReset={onMicReset}
+				onStreamChange={onStreamChange}
+				onStreamReset={onStreamReset}
+			/>
+		</div>
+	);
+}

--- a/src/components/CallUi/ParticipantContextMenu/ParticipantVolumeMenu.tsx
+++ b/src/components/CallUi/ParticipantContextMenu/ParticipantVolumeMenu.tsx
@@ -1,0 +1,40 @@
+import { ParticipantVolumeRow } from "../AudioMixPanel/ParticipantVolumeRow";
+
+interface ParticipantVolumeMenuProps {
+	micVolume: number;
+	streamVolume: number;
+	hasScreenShareAudio: boolean;
+	onMicChange: (value: number) => void;
+	onMicReset: () => void;
+	onStreamChange: (value: number) => void;
+	onStreamReset: () => void;
+}
+
+export function ParticipantVolumeMenu({
+	micVolume,
+	streamVolume,
+	hasScreenShareAudio,
+	onMicChange,
+	onMicReset,
+	onStreamChange,
+	onStreamReset,
+}: ParticipantVolumeMenuProps) {
+	return (
+		<div>
+			<ParticipantVolumeRow
+				source="microphone"
+				value={micVolume}
+				onChange={onMicChange}
+				onReset={onMicReset}
+			/>
+			{hasScreenShareAudio && (
+				<ParticipantVolumeRow
+					source="screenShareAudio"
+					value={streamVolume}
+					onChange={onStreamChange}
+					onReset={onStreamReset}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/components/CallUi/TheaterMode/TheaterModeView.module.css
+++ b/src/components/CallUi/TheaterMode/TheaterModeView.module.css
@@ -1,0 +1,65 @@
+.root {
+	position: relative;
+	flex: 1;
+	min-height: 0;
+	border-radius: 12px;
+	overflow: hidden;
+	background: #000;
+}
+
+.media,
+.media video {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	background: #000;
+}
+
+.loading {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: rgba(255, 255, 255, 0.72);
+	font-weight: 700;
+}
+
+.overlayTop {
+	position: absolute;
+	top: 10px;
+	left: 10px;
+	right: 10px;
+	z-index: 2;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.title {
+	max-width: 70%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	font-size: 12px;
+	font-weight: 700;
+	color: #fff;
+	padding: 6px 10px;
+	border-radius: 999px;
+	background: rgba(0, 0, 0, 0.45);
+}
+
+.exitButton {
+	height: 30px;
+	padding: 0 10px;
+	border-radius: 999px;
+	border: none;
+	background: rgba(0, 0, 0, 0.58);
+	color: #fff;
+	cursor: pointer;
+}
+
+.exitButton:hover {
+	background: rgba(0, 0, 0, 0.7);
+}

--- a/src/components/CallUi/TheaterMode/TheaterModeView.tsx
+++ b/src/components/CallUi/TheaterMode/TheaterModeView.tsx
@@ -1,0 +1,30 @@
+import { VideoTrack, type TrackReference } from "@livekit/components-react";
+import styles from "./TheaterModeView.module.css";
+
+interface TheaterModeViewProps {
+	trackRef: TrackReference;
+	displayName: string;
+	onExit: () => void;
+}
+
+export function TheaterModeView({ trackRef, displayName, onExit }: TheaterModeViewProps) {
+	const isReady = trackRef.participant.isLocal || trackRef.publication?.isSubscribed;
+
+	return (
+		<div className={styles["root"]}>
+			<div className={styles["overlayTop"]}>
+				<div className={styles["title"]}>Screen share by {displayName}</div>
+				<button type="button" className={styles["exitButton"]} onClick={onExit}>
+					Exit theater
+				</button>
+			</div>
+			<div className={styles["media"]}>
+				{isReady ? (
+					<VideoTrack trackRef={trackRef} />
+				) : (
+					<div className={styles["loading"]}>Opening screen share...</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/CallUi/UserProfilePopover/UserProfilePopover.module.css
+++ b/src/components/CallUi/UserProfilePopover/UserProfilePopover.module.css
@@ -1,0 +1,5 @@
+.popover {
+	position: fixed;
+	z-index: 42;
+	max-width: min(360px, calc(100vw - 16px));
+}

--- a/src/components/CallUi/UserProfilePopover/UserProfilePopover.tsx
+++ b/src/components/CallUi/UserProfilePopover/UserProfilePopover.tsx
@@ -1,0 +1,38 @@
+import { UserProfileCard } from "../../UserProfileCard/UserProfileCard";
+import styles from "./UserProfilePopover.module.css";
+
+interface UserProfilePopoverProps {
+	x: number;
+	y: number;
+	displayName: string;
+	username?: string;
+	avatarUrl?: string | null;
+	avatarBg: string;
+	aboutMe?: string | null;
+}
+
+export function UserProfilePopover({
+	x,
+	y,
+	displayName,
+	username,
+	avatarUrl,
+	avatarBg,
+	aboutMe,
+}: UserProfilePopoverProps) {
+	return (
+		<div
+			className={styles["popover"]}
+			style={{ top: y, left: x }}
+			onClick={(event) => event.stopPropagation()}
+		>
+			<UserProfileCard
+				displayName={displayName}
+				username={username}
+				avatarUrl={avatarUrl}
+				avatarBg={avatarBg}
+				aboutMe={aboutMe}
+			/>
+		</div>
+	);
+}

--- a/src/components/CallUi/useMicrophoneCaptureOptions.ts
+++ b/src/components/CallUi/useMicrophoneCaptureOptions.ts
@@ -12,14 +12,19 @@ export function useMicrophoneCaptureOptions(): AudioCaptureOptions {
 				device.selectedMicrophoneId !== "default"
 					? device.selectedMicrophoneId
 					: undefined,
-			autoGainControl: true,
-			echoCancellation: true,
+			autoGainControl: device.isAutoGainControlEnabled,
+			echoCancellation: device.isEchoCancellationEnabled,
 			noiseSuppression: device.isNoiseSuppressionEnabled,
 			voiceIsolation: device.isNoiseSuppressionEnabled,
 			channelCount: 1,
 			sampleRate: 48000,
 			sampleSize: 16,
 		}),
-		[device.selectedMicrophoneId, device.isNoiseSuppressionEnabled]
+		[
+			device.selectedMicrophoneId,
+			device.isNoiseSuppressionEnabled,
+			device.isEchoCancellationEnabled,
+			device.isAutoGainControlEnabled,
+		]
 	);
 }

--- a/src/components/FriendsList/FriendsList.tsx
+++ b/src/components/FriendsList/FriendsList.tsx
@@ -44,7 +44,7 @@ console.log(friends)
 									e.stopPropagation();
 									removeHandle(friend.friendUsername);
 								}}>
-								<img src="../../../public/cross-icon.svg" />
+								<img src="/cross-icon.svg" />
 							</button>
 						</div>
 					</div>

--- a/src/components/NavigateBar/NavigateBar.tsx
+++ b/src/components/NavigateBar/NavigateBar.tsx
@@ -38,7 +38,7 @@ export function NavigateBar({ servers }: NavigateBarProps) {
 	return <div className={styles["navigate-bar"]}>
 		<div className={styles["top"]}>
 			<NavigateBarButton onClick={goToDM}>
-				<img src="../../../public/message-nav-icon.png" />
+				<img src="/message-nav-icon.png" />
 				{requestsCount > 0 && (
 					<span className={styles["messages-badge"]}></span>
 				)}
@@ -49,7 +49,7 @@ export function NavigateBar({ servers }: NavigateBarProps) {
 
 		<div className={styles["middle"]}>
 			<NavigateBarButton onClick={() => navigate("/my-servers")}>
-				<img src="../../../public/server-all-list-icon.png" />
+				<img src="/server-all-list-icon.png" />
 			</NavigateBarButton>
 			{servers.map((server, index) => (
 				<ServerButton
@@ -63,7 +63,7 @@ export function NavigateBar({ servers }: NavigateBarProps) {
 
 		<div className={styles["bottom"]}>
 			<NavigateBarButton onClick={notificationHandle}>
-				<img src="../../../public/notify-icon.png" />
+				<img src="/notify-icon.png" />
 
 				{unreadNotification > 0 && (
 					<span className={styles["messages-badge"]}/>

--- a/src/components/ServerButton/ServerButton.tsx
+++ b/src/components/ServerButton/ServerButton.tsx
@@ -16,7 +16,7 @@ export function ServerButton({ server, index, onClick }: ServerButtonProps) {
 			title={server.name}
 			onClick={onClick}
 		>
-			<img src="../../../public/server-button-img2.png" alt={server.name} />
+			<img src="/server-button-img2.png" alt={server.name} />
 		</button>
 	)
 }

--- a/src/components/VoiceVideoSetting/CameraPreview/CameraPreviewCard.tsx
+++ b/src/components/VoiceVideoSetting/CameraPreview/CameraPreviewCard.tsx
@@ -1,0 +1,41 @@
+import styles from "../VoiceVideoSetting.module.css";
+import { CameraPreviewState } from "./CameraPreviewState";
+import type { CameraPreviewStatus } from "./useCameraPreview";
+import type { RefObject } from "react";
+
+interface CameraPreviewCardProps {
+	status: CameraPreviewStatus;
+	error: string | null;
+	selectedCameraLabel: string;
+	videoRef: RefObject<HTMLVideoElement | null>;
+}
+
+export function CameraPreviewCard({
+	status,
+	error,
+	selectedCameraLabel,
+	videoRef,
+}: CameraPreviewCardProps) {
+	return (
+		<div className={styles["camera-preview-card"]}>
+			<div className={styles["camera-preview-media"]}>
+				{status === "ready" ? (
+					<video
+						ref={videoRef}
+						className={styles["camera-preview-video"]}
+						autoPlay
+						playsInline
+						muted
+					/>
+				) : (
+					<CameraPreviewState status={status} />
+				)}
+			</div>
+			<div className={styles["camera-preview-caption"]}>{selectedCameraLabel}</div>
+			<div className={styles["help-text"]}>
+				Preview is local only and is not sent to the call.
+			</div>
+			{error && <div className={styles["error-text"]}>{error}</div>}
+		</div>
+	);
+}

--- a/src/components/VoiceVideoSetting/CameraPreview/CameraPreviewState.tsx
+++ b/src/components/VoiceVideoSetting/CameraPreview/CameraPreviewState.tsx
@@ -1,0 +1,19 @@
+import styles from "../VoiceVideoSetting.module.css";
+import type { CameraPreviewStatus } from "./useCameraPreview";
+
+interface CameraPreviewStateProps {
+	status: CameraPreviewStatus;
+}
+
+export function CameraPreviewState({ status }: CameraPreviewStateProps) {
+	return (
+		<div className={styles["camera-preview-state"]}>
+			{status === "loading" && "Loading camera preview..."}
+			{status === "denied" && "Camera permission denied."}
+			{status === "not_found" && "Selected camera is unavailable."}
+			{status === "error" && "Could not start camera preview."}
+			{status === "no_device" && "No camera devices found."}
+			{status === "idle" && "Preparing camera preview..."}
+		</div>
+	);
+}

--- a/src/components/VoiceVideoSetting/CameraPreview/useCameraPreview.ts
+++ b/src/components/VoiceVideoSetting/CameraPreview/useCameraPreview.ts
@@ -1,5 +1,11 @@
-import { useEffect, useRef, useState } from "react";
-import { getCameraCaptureOptions, type CallQualityRecommendation, type CallQualitySetting, getQualityPreset, resolveQualitySetting } from "../../../utils/callQuality";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	getCameraCaptureOptions,
+	type CallQualityRecommendation,
+	type CallQualitySetting,
+	getQualityPreset,
+	resolveQualitySetting,
+} from "../../../utils/callQuality";
 
 export type CameraPreviewStatus =
 	| "idle"
@@ -27,20 +33,35 @@ export function useCameraPreview({
 	const [error, setError] = useState<string | null>(null);
 	const streamRef = useRef<MediaStream | null>(null);
 	const videoElementRef = useRef<HTMLVideoElement | null>(null);
+	const requestIdRef = useRef(0);
+
+	const resolvedCameraQuality = useMemo(
+		() => resolveQualitySetting("camera", cameraQuality, recommendation),
+		[cameraQuality, recommendation]
+	);
 
 	useEffect(() => {
-		const stopPreview = () => {
-			if (streamRef.current) {
-				streamRef.current.getTracks().forEach((track) => track.stop());
-				streamRef.current = null;
-			}
-			if (videoElementRef.current) {
-				videoElementRef.current.srcObject = null;
+		const stopStream = (stream: MediaStream | null) => {
+			if (!stream) return;
+			stream.getTracks().forEach((track) => track.stop());
+		};
+
+		const detachCurrentVideo = () => {
+			const video = videoElementRef.current;
+			if (!video) return;
+			if (video.srcObject === streamRef.current) {
+				video.srcObject = null;
 			}
 		};
 
 		const startPreview = async () => {
-			stopPreview();
+			requestIdRef.current += 1;
+			const requestId = requestIdRef.current;
+
+			detachCurrentVideo();
+			stopStream(streamRef.current);
+			streamRef.current = null;
+
 			setStatus("loading");
 			setError(null);
 
@@ -57,10 +78,7 @@ export function useCameraPreview({
 			}
 
 			try {
-				const preset = getQualityPreset(
-					"camera",
-					resolveQualitySetting("camera", cameraQuality, recommendation)
-				);
+				const preset = getQualityPreset("camera", resolvedCameraQuality);
 				const captureOptions = getCameraCaptureOptions(selectedCameraId, preset);
 				const resolution = captureOptions.resolution;
 
@@ -75,15 +93,16 @@ export function useCameraPreview({
 					audio: false,
 				});
 
-				streamRef.current = stream;
-
-				if (videoElementRef.current) {
-					videoElementRef.current.srcObject = stream;
-					await videoElementRef.current.play().catch(() => undefined);
+				if (requestId !== requestIdRef.current) {
+					stopStream(stream);
+					return;
 				}
 
+				streamRef.current = stream;
 				setStatus("ready");
 			} catch (rawError) {
+				if (requestId !== requestIdRef.current) return;
+
 				const mediaError = rawError as DOMException;
 				if (mediaError?.name === "NotAllowedError") {
 					setStatus("denied");
@@ -107,9 +126,31 @@ export function useCameraPreview({
 		void startPreview();
 
 		return () => {
-			stopPreview();
+			requestIdRef.current += 1;
+			detachCurrentVideo();
+			stopStream(streamRef.current);
+			streamRef.current = null;
 		};
-	}, [selectedCameraId, cameraQuality, recommendation, hasCameraDevices]);
+	}, [selectedCameraId, resolvedCameraQuality, hasCameraDevices]);
+
+	useEffect(() => {
+		if (status !== "ready") return;
+
+		const stream = streamRef.current;
+		const video = videoElementRef.current;
+		if (!stream || !video) return;
+
+		video.srcObject = stream;
+		video.muted = true;
+		video.playsInline = true;
+		void video.play().catch(() => undefined);
+
+		return () => {
+			if (video.srcObject === stream) {
+				video.srcObject = null;
+			}
+		};
+	}, [status]);
 
 	return {
 		status,

--- a/src/components/VoiceVideoSetting/CameraPreview/useCameraPreview.ts
+++ b/src/components/VoiceVideoSetting/CameraPreview/useCameraPreview.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from "react";
+import { getCameraCaptureOptions, type CallQualityRecommendation, type CallQualitySetting, getQualityPreset, resolveQualitySetting } from "../../../utils/callQuality";
+
+export type CameraPreviewStatus =
+	| "idle"
+	| "loading"
+	| "ready"
+	| "no_device"
+	| "denied"
+	| "not_found"
+	| "error";
+
+interface UseCameraPreviewParams {
+	selectedCameraId: string;
+	cameraQuality: CallQualitySetting;
+	recommendation: CallQualityRecommendation | null;
+	hasCameraDevices: boolean;
+}
+
+export function useCameraPreview({
+	selectedCameraId,
+	cameraQuality,
+	recommendation,
+	hasCameraDevices,
+}: UseCameraPreviewParams) {
+	const [status, setStatus] = useState<CameraPreviewStatus>("idle");
+	const [error, setError] = useState<string | null>(null);
+	const streamRef = useRef<MediaStream | null>(null);
+	const videoElementRef = useRef<HTMLVideoElement | null>(null);
+
+	useEffect(() => {
+		const stopPreview = () => {
+			if (streamRef.current) {
+				streamRef.current.getTracks().forEach((track) => track.stop());
+				streamRef.current = null;
+			}
+			if (videoElementRef.current) {
+				videoElementRef.current.srcObject = null;
+			}
+		};
+
+		const startPreview = async () => {
+			stopPreview();
+			setStatus("loading");
+			setError(null);
+
+			if (!navigator.mediaDevices?.getUserMedia) {
+				setStatus("error");
+				setError("Camera preview is not supported in this browser.");
+				return;
+			}
+
+			if (!hasCameraDevices) {
+				setStatus("no_device");
+				setError("No camera devices were detected.");
+				return;
+			}
+
+			try {
+				const preset = getQualityPreset(
+					"camera",
+					resolveQualitySetting("camera", cameraQuality, recommendation)
+				);
+				const captureOptions = getCameraCaptureOptions(selectedCameraId, preset);
+				const resolution = captureOptions.resolution;
+
+				const stream = await navigator.mediaDevices.getUserMedia({
+					video: {
+						deviceId: captureOptions.deviceId,
+						facingMode: captureOptions.facingMode,
+						width: resolution?.width,
+						height: resolution?.height,
+						frameRate: resolution?.frameRate,
+					},
+					audio: false,
+				});
+
+				streamRef.current = stream;
+
+				if (videoElementRef.current) {
+					videoElementRef.current.srcObject = stream;
+					await videoElementRef.current.play().catch(() => undefined);
+				}
+
+				setStatus("ready");
+			} catch (rawError) {
+				const mediaError = rawError as DOMException;
+				if (mediaError?.name === "NotAllowedError") {
+					setStatus("denied");
+					setError("Camera permission denied.");
+					return;
+				}
+				if (
+					mediaError?.name === "NotFoundError" ||
+					mediaError?.name === "OverconstrainedError"
+				) {
+					setStatus("not_found");
+					setError("Selected camera is unavailable.");
+					return;
+				}
+
+				setStatus("error");
+				setError("Could not start camera preview.");
+			}
+		};
+
+		void startPreview();
+
+		return () => {
+			stopPreview();
+		};
+	}, [selectedCameraId, cameraQuality, recommendation, hasCameraDevices]);
+
+	return {
+		status,
+		error,
+		videoElementRef,
+	};
+}

--- a/src/components/VoiceVideoSetting/VoiceVideoSetting.module.css
+++ b/src/components/VoiceVideoSetting/VoiceVideoSetting.module.css
@@ -184,3 +184,47 @@
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
 }
+
+.camera-preview-card {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 10px;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	background: var(--bg-input);
+}
+
+.camera-preview-media {
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	border-radius: 8px;
+	overflow: hidden;
+	background: #000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.camera-preview-video {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.camera-preview-state {
+	color: var(--text-secondary);
+	font-size: 13px;
+	padding: 0 12px;
+	text-align: center;
+}
+
+.camera-preview-caption {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text-primary);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}

--- a/src/components/VoiceVideoSetting/VoiceVideoSetting.tsx
+++ b/src/components/VoiceVideoSetting/VoiceVideoSetting.tsx
@@ -12,6 +12,7 @@ import {
 	recommendQualityFromMetrics,
 	type NetworkQualityMetrics,
 	type CallQualitySetting,
+	type ScreenShareQualitySetting,
 } from "../../utils/callQuality";
 
 interface PublishStats {
@@ -37,6 +38,11 @@ export function VoiceVideoSetting() {
 		cameraQuality,
 		screenShareQuality,
 		isNoiseSuppressionEnabled,
+		isEchoCancellationEnabled,
+		isAutoGainControlEnabled,
+		voiceActivityThreshold,
+		isAutoInputSensitivity,
+		screenShareRuntime,
 		connectionTestResult,
 	} = useSelector((s: RootState) => s.device);
 	const myUser = useSelector((s: RootState) => s.user.myUser);
@@ -78,8 +84,8 @@ export function VoiceVideoSetting() {
 						selectedMicrophoneId === "default"
 							? undefined
 							: { exact: selectedMicrophoneId },
-					autoGainControl: true,
-					echoCancellation: true,
+					autoGainControl: isAutoGainControlEnabled,
+					echoCancellation: isEchoCancellationEnabled,
 					noiseSuppression: isNoiseSuppressionEnabled,
 					channelCount: 1,
 					sampleRate: 48000,
@@ -154,7 +160,13 @@ export function VoiceVideoSetting() {
 				streamRef.current.getTracks().forEach((track) => track.stop());
 			}
 		};
-	}, [selectedMicrophoneId, isListening, isNoiseSuppressionEnabled]);
+	}, [
+		selectedMicrophoneId,
+		isListening,
+		isNoiseSuppressionEnabled,
+		isEchoCancellationEnabled,
+		isAutoGainControlEnabled,
+	]);
 
 	const runConnectionTest = async () => {
 		dispatch(deviceActions.setConnectionTestRunning());
@@ -280,6 +292,30 @@ export function VoiceVideoSetting() {
 					</div>
 
 					<div className={styles["form-group"]}>
+						<label className={styles["label"]}>Echo Cancellation</label>
+						<label className={styles["toggle-row"]}>
+							<input
+								type="checkbox"
+								checked={isEchoCancellationEnabled}
+								onChange={(e) => dispatch(deviceActions.setEchoCancellation(e.target.checked))}
+							/>
+							<span>{isEchoCancellationEnabled ? "Enabled" : "Disabled"}</span>
+						</label>
+					</div>
+
+					<div className={styles["form-group"]}>
+						<label className={styles["label"]}>Auto Gain Control</label>
+						<label className={styles["toggle-row"]}>
+							<input
+								type="checkbox"
+								checked={isAutoGainControlEnabled}
+								onChange={(e) => dispatch(deviceActions.setAutoGainControl(e.target.checked))}
+							/>
+							<span>{isAutoGainControlEnabled ? "Enabled" : "Disabled"}</span>
+						</label>
+					</div>
+
+					<div className={styles["form-group"]}>
 						<label className={styles["label"]}>Microphone Test</label>
 						<div className={styles["volume-bar-bg"]}>
 							<div
@@ -293,7 +329,39 @@ export function VoiceVideoSetting() {
 						>
 							{isListening ? "Stop monitoring" : "Monitor myself"}
 						</button>
+						<div className={styles["help-text"]}>
+							Voice activity:{" "}
+							{volumeLevel >= (isAutoInputSensitivity ? 30 : voiceActivityThreshold)
+								? "Detected"
+								: "Below threshold"}
+						</div>
 						<audio ref={audioPreviewRef} autoPlay style={{ display: "none" }} />
+					</div>
+
+					<div className={styles["form-group"]}>
+						<label className={styles["label"]}>Input sensitivity / Voice activity threshold</label>
+						<label className={styles["toggle-row"]}>
+							<input
+								type="checkbox"
+								checked={isAutoInputSensitivity}
+								onChange={(e) => dispatch(deviceActions.setAutoInputSensitivity(e.target.checked))}
+							/>
+							<span>{isAutoInputSensitivity ? "Auto sensitivity" : "Manual threshold"}</span>
+						</label>
+						<input
+							type="range"
+							min={5}
+							max={90}
+							step={1}
+							disabled={isAutoInputSensitivity}
+							value={voiceActivityThreshold}
+							onChange={(e) =>
+								dispatch(deviceActions.setVoiceActivityThreshold(Number(e.target.value)))
+							}
+						/>
+						<span className={styles["help-text"]}>
+							Lower sensitivity may cut background noise but can also cut quiet speech.
+						</span>
 					</div>
 
 					<div className={styles["form-group"]}>
@@ -318,14 +386,27 @@ export function VoiceVideoSetting() {
 							className={styles["input"]}
 							value={screenShareQuality}
 							onChange={(e) =>
-								dispatch(deviceActions.setScreenShareQuality(e.target.value as CallQualitySetting))
+								dispatch(deviceActions.setScreenShareQuality(e.target.value as ScreenShareQualitySetting))
 							}
 						>
 							<option value="auto">Auto</option>
 							<option value="high">High (1080p, 30 FPS)</option>
 							<option value="medium">Medium (1080p, 15 FPS)</option>
 							<option value="low">Low (720p, 5 FPS)</option>
+							<option value="game60">Gaming 1080p60</option>
+							<option value="game120">Gaming 1080p120 Experimental</option>
 						</select>
+						{screenShareQuality === "game120" && (
+							<span className={styles["help-text"]}>
+								Experimental. Requires strong upload and browser/source support. 120 FPS is best effort, not guaranteed.
+							</span>
+						)}
+						{screenShareRuntime.updatedAt && (
+							<div className={styles["summary-text"]}>
+								Requested FPS: {screenShareRuntime.requestedFps ?? "N/A"}, actual: {screenShareRuntime.actualFps ?? "N/A"}, applied mode: {screenShareRuntime.activePreset ?? "N/A"}.
+								{screenShareRuntime.fallbackReason ? ` ${screenShareRuntime.fallbackReason}` : ""}
+							</div>
+						)}
 					</div>
 
 					<div className={styles["form-group"]}>

--- a/src/components/VoiceVideoSetting/VoiceVideoSetting.tsx
+++ b/src/components/VoiceVideoSetting/VoiceVideoSetting.tsx
@@ -9,14 +9,13 @@ import {
 	formatBitrate,
 	formatMilliseconds,
 	formatPercent,
-	getCameraCaptureOptions,
-	getQualityPreset,
 	recommendQualityFromMetrics,
-	resolveQualitySetting,
 	type NetworkQualityMetrics,
 	type CallQualitySetting,
 	type ScreenShareQualitySetting,
 } from "../../utils/callQuality";
+import { useCameraPreview } from "./CameraPreview/useCameraPreview";
+import { CameraPreviewCard } from "./CameraPreview/CameraPreviewCard";
 
 interface PublishStats {
 	packetsLost: number;
@@ -57,17 +56,11 @@ export function VoiceVideoSetting() {
 	const [mediaDevicesReady, setMediaDevicesReady] = useState(false);
 	const [volumeLevel, setVolumeLevel] = useState(0);
 	const [isListening, setIsListening] = useState(false);
-	const [cameraPreviewStatus, setCameraPreviewStatus] = useState<
-		"idle" | "loading" | "ready" | "no_device" | "denied" | "not_found" | "error"
-	>("idle");
-	const [cameraPreviewError, setCameraPreviewError] = useState<string | null>(null);
 
 	const streamRef = useRef<MediaStream | null>(null);
 	const audioContextRef = useRef<AudioContext | null>(null);
 	const audioPreviewRef = useRef<HTMLAudioElement | null>(null);
 	const animationRef = useRef<number | null>(null);
-	const cameraPreviewStreamRef = useRef<MediaStream | null>(null);
-	const cameraPreviewVideoRef = useRef<HTMLVideoElement | null>(null);
 
 	useEffect(() => {
 		const getDevices = async () => {
@@ -86,91 +79,19 @@ export function VoiceVideoSetting() {
 		getDevices();
 	}, []);
 
-	const cameraPreviewPreset = getQualityPreset(
-		"camera",
-		resolveQualitySetting("camera", cameraQuality, recommendation)
-	);
-
 	const selectedCameraLabel =
 		cameras.find((camera) => camera.deviceId === selectedCameraId)?.label ||
 		(selectedCameraId === "default" ? "Default camera" : "Selected camera");
-
-	useEffect(() => {
-		const stopCameraPreviewTracks = () => {
-			if (cameraPreviewStreamRef.current) {
-				cameraPreviewStreamRef.current.getTracks().forEach((track) => track.stop());
-				cameraPreviewStreamRef.current = null;
-			}
-			if (cameraPreviewVideoRef.current) {
-				cameraPreviewVideoRef.current.srcObject = null;
-			}
-		};
-
-		const startCameraPreview = async () => {
-			stopCameraPreviewTracks();
-			setCameraPreviewStatus("loading");
-			setCameraPreviewError(null);
-			if (mediaDevicesReady && cameras.length === 0) {
-				setCameraPreviewStatus("no_device");
-				setCameraPreviewError("No camera devices were detected.");
-				return;
-			}
-
-			if (!navigator.mediaDevices?.getUserMedia) {
-				setCameraPreviewStatus("error");
-				setCameraPreviewError("Camera preview is not supported in this browser.");
-				return;
-			}
-
-			try {
-				const captureOptions = getCameraCaptureOptions(
-					selectedCameraId,
-					cameraPreviewPreset
-				);
-				const resolution = captureOptions.resolution;
-				const videoConstraints: MediaTrackConstraints = {
-					deviceId: captureOptions.deviceId,
-					facingMode: captureOptions.facingMode,
-					width: resolution?.width,
-					height: resolution?.height,
-					frameRate: resolution?.frameRate,
-				};
-
-				const stream = await navigator.mediaDevices.getUserMedia({
-					video: videoConstraints,
-					audio: false,
-				});
-				cameraPreviewStreamRef.current = stream;
-
-				if (cameraPreviewVideoRef.current) {
-					cameraPreviewVideoRef.current.srcObject = stream;
-					await cameraPreviewVideoRef.current.play().catch(() => undefined);
-				}
-
-				setCameraPreviewStatus("ready");
-			} catch (error) {
-				const mediaError = error as DOMException;
-				if (mediaError?.name === "NotAllowedError") {
-					setCameraPreviewStatus("denied");
-					setCameraPreviewError("Camera permission denied.");
-					return;
-				}
-				if (mediaError?.name === "NotFoundError" || mediaError?.name === "OverconstrainedError") {
-					setCameraPreviewStatus("not_found");
-					setCameraPreviewError("Selected camera is unavailable.");
-					return;
-				}
-				setCameraPreviewStatus("error");
-				setCameraPreviewError("Could not start camera preview.");
-			}
-		};
-
-		void startCameraPreview();
-
-		return () => {
-			stopCameraPreviewTracks();
-		};
-	}, [selectedCameraId, cameraPreviewPreset, cameras.length, mediaDevicesReady]);
+	const {
+		status: cameraPreviewStatus,
+		error: cameraPreviewError,
+		videoElementRef: cameraPreviewVideoRef,
+	} = useCameraPreview({
+		selectedCameraId,
+		cameraQuality,
+		recommendation,
+		hasCameraDevices: !mediaDevicesReady || cameras.length > 0,
+	});
 
 	useEffect(() => {
 		const startAudio = async () => {
@@ -359,34 +280,12 @@ export function VoiceVideoSetting() {
 
 					<div className={styles["form-group"]}>
 						<label className={styles["label"]}>Camera Preview</label>
-						<div className={styles["camera-preview-card"]}>
-							<div className={styles["camera-preview-media"]}>
-								{cameraPreviewStatus === "ready" ? (
-									<video
-										ref={cameraPreviewVideoRef}
-										className={styles["camera-preview-video"]}
-										autoPlay
-										playsInline
-										muted
-									/>
-								) : (
-									<div className={styles["camera-preview-state"]}>
-										{cameraPreviewStatus === "loading" && "Loading camera preview..."}
-										{cameraPreviewStatus === "denied" && "Camera permission denied."}
-										{cameraPreviewStatus === "not_found" && "Selected camera is unavailable."}
-										{cameraPreviewStatus === "error" && "Could not start camera preview."}
-										{cameraPreviewStatus === "no_device" && "No camera devices found."}
-									</div>
-								)}
-							</div>
-							<div className={styles["camera-preview-caption"]}>{selectedCameraLabel}</div>
-							<div className={styles["help-text"]}>
-								Preview is local only and is not sent to the call.
-							</div>
-							{cameraPreviewError && (
-								<div className={styles["error-text"]}>{cameraPreviewError}</div>
-							)}
-						</div>
+						<CameraPreviewCard
+							status={cameraPreviewStatus}
+							error={cameraPreviewError}
+							selectedCameraLabel={selectedCameraLabel}
+							videoRef={cameraPreviewVideoRef}
+						/>
 					</div>
 
 					<div className={styles["form-group"]}>

--- a/src/components/VoiceVideoSetting/VoiceVideoSetting.tsx
+++ b/src/components/VoiceVideoSetting/VoiceVideoSetting.tsx
@@ -9,7 +9,10 @@ import {
 	formatBitrate,
 	formatMilliseconds,
 	formatPercent,
+	getCameraCaptureOptions,
+	getQualityPreset,
 	recommendQualityFromMetrics,
+	resolveQualitySetting,
 	type NetworkQualityMetrics,
 	type CallQualitySetting,
 	type ScreenShareQualitySetting,
@@ -46,16 +49,25 @@ export function VoiceVideoSetting() {
 		connectionTestResult,
 	} = useSelector((s: RootState) => s.device);
 	const myUser = useSelector((s: RootState) => s.user.myUser);
+	const recommendation = connectionTestResult.recommendation;
+	const metrics = connectionTestResult.metrics;
 
 	const [cameras, setCameras] = useState<MediaDeviceInfo[]>([]);
 	const [microphones, setMicrophones] = useState<MediaDeviceInfo[]>([]);
+	const [mediaDevicesReady, setMediaDevicesReady] = useState(false);
 	const [volumeLevel, setVolumeLevel] = useState(0);
 	const [isListening, setIsListening] = useState(false);
+	const [cameraPreviewStatus, setCameraPreviewStatus] = useState<
+		"idle" | "loading" | "ready" | "no_device" | "denied" | "not_found" | "error"
+	>("idle");
+	const [cameraPreviewError, setCameraPreviewError] = useState<string | null>(null);
 
 	const streamRef = useRef<MediaStream | null>(null);
 	const audioContextRef = useRef<AudioContext | null>(null);
 	const audioPreviewRef = useRef<HTMLAudioElement | null>(null);
 	const animationRef = useRef<number | null>(null);
+	const cameraPreviewStreamRef = useRef<MediaStream | null>(null);
+	const cameraPreviewVideoRef = useRef<HTMLVideoElement | null>(null);
 
 	useEffect(() => {
 		const getDevices = async () => {
@@ -66,11 +78,99 @@ export function VoiceVideoSetting() {
 				setMicrophones(devices.filter((device) => device.kind === "audioinput"));
 			} catch (error) {
 				console.log("No access to media devices", error);
+			} finally {
+				setMediaDevicesReady(true);
 			}
 		};
 
 		getDevices();
 	}, []);
+
+	const cameraPreviewPreset = getQualityPreset(
+		"camera",
+		resolveQualitySetting("camera", cameraQuality, recommendation)
+	);
+
+	const selectedCameraLabel =
+		cameras.find((camera) => camera.deviceId === selectedCameraId)?.label ||
+		(selectedCameraId === "default" ? "Default camera" : "Selected camera");
+
+	useEffect(() => {
+		const stopCameraPreviewTracks = () => {
+			if (cameraPreviewStreamRef.current) {
+				cameraPreviewStreamRef.current.getTracks().forEach((track) => track.stop());
+				cameraPreviewStreamRef.current = null;
+			}
+			if (cameraPreviewVideoRef.current) {
+				cameraPreviewVideoRef.current.srcObject = null;
+			}
+		};
+
+		const startCameraPreview = async () => {
+			stopCameraPreviewTracks();
+			setCameraPreviewStatus("loading");
+			setCameraPreviewError(null);
+			if (mediaDevicesReady && cameras.length === 0) {
+				setCameraPreviewStatus("no_device");
+				setCameraPreviewError("No camera devices were detected.");
+				return;
+			}
+
+			if (!navigator.mediaDevices?.getUserMedia) {
+				setCameraPreviewStatus("error");
+				setCameraPreviewError("Camera preview is not supported in this browser.");
+				return;
+			}
+
+			try {
+				const captureOptions = getCameraCaptureOptions(
+					selectedCameraId,
+					cameraPreviewPreset
+				);
+				const resolution = captureOptions.resolution;
+				const videoConstraints: MediaTrackConstraints = {
+					deviceId: captureOptions.deviceId,
+					facingMode: captureOptions.facingMode,
+					width: resolution?.width,
+					height: resolution?.height,
+					frameRate: resolution?.frameRate,
+				};
+
+				const stream = await navigator.mediaDevices.getUserMedia({
+					video: videoConstraints,
+					audio: false,
+				});
+				cameraPreviewStreamRef.current = stream;
+
+				if (cameraPreviewVideoRef.current) {
+					cameraPreviewVideoRef.current.srcObject = stream;
+					await cameraPreviewVideoRef.current.play().catch(() => undefined);
+				}
+
+				setCameraPreviewStatus("ready");
+			} catch (error) {
+				const mediaError = error as DOMException;
+				if (mediaError?.name === "NotAllowedError") {
+					setCameraPreviewStatus("denied");
+					setCameraPreviewError("Camera permission denied.");
+					return;
+				}
+				if (mediaError?.name === "NotFoundError" || mediaError?.name === "OverconstrainedError") {
+					setCameraPreviewStatus("not_found");
+					setCameraPreviewError("Selected camera is unavailable.");
+					return;
+				}
+				setCameraPreviewStatus("error");
+				setCameraPreviewError("Could not start camera preview.");
+			}
+		};
+
+		void startCameraPreview();
+
+		return () => {
+			stopCameraPreviewTracks();
+		};
+	}, [selectedCameraId, cameraPreviewPreset, cameras.length, mediaDevicesReady]);
 
 	useEffect(() => {
 		const startAudio = async () => {
@@ -201,9 +301,6 @@ export function VoiceVideoSetting() {
 		}
 	};
 
-	const recommendation = connectionTestResult.recommendation;
-	const metrics = connectionTestResult.metrics;
-
 	function getNetworkMetrics(stats: PublishStats | null): NetworkQualityMetrics {
 		const browserNetwork = getBrowserNetworkInfo();
 		const sampleCount = stats?.count ?? 0;
@@ -252,12 +349,44 @@ export function VoiceVideoSetting() {
 							onChange={(e) => dispatch(deviceActions.setCamera(e.target.value))}
 						>
 							<option value="default">Default</option>
-							{cameras.map((camera) => (
+							{cameras.map((camera, index) => (
 								<option key={camera.deviceId} value={camera.deviceId}>
-									{camera.label || "Camera"}
+									{getDeviceLabel(camera, index, "Camera")}
 								</option>
 							))}
 						</select>
+					</div>
+
+					<div className={styles["form-group"]}>
+						<label className={styles["label"]}>Camera Preview</label>
+						<div className={styles["camera-preview-card"]}>
+							<div className={styles["camera-preview-media"]}>
+								{cameraPreviewStatus === "ready" ? (
+									<video
+										ref={cameraPreviewVideoRef}
+										className={styles["camera-preview-video"]}
+										autoPlay
+										playsInline
+										muted
+									/>
+								) : (
+									<div className={styles["camera-preview-state"]}>
+										{cameraPreviewStatus === "loading" && "Loading camera preview..."}
+										{cameraPreviewStatus === "denied" && "Camera permission denied."}
+										{cameraPreviewStatus === "not_found" && "Selected camera is unavailable."}
+										{cameraPreviewStatus === "error" && "Could not start camera preview."}
+										{cameraPreviewStatus === "no_device" && "No camera devices found."}
+									</div>
+								)}
+							</div>
+							<div className={styles["camera-preview-caption"]}>{selectedCameraLabel}</div>
+							<div className={styles["help-text"]}>
+								Preview is local only and is not sent to the call.
+							</div>
+							{cameraPreviewError && (
+								<div className={styles["error-text"]}>{cameraPreviewError}</div>
+							)}
+						</div>
 					</div>
 
 					<div className={styles["form-group"]}>
@@ -268,9 +397,9 @@ export function VoiceVideoSetting() {
 							onChange={(e) => dispatch(deviceActions.setMicrophone(e.target.value))}
 						>
 							<option value="default">Default</option>
-							{microphones.map((microphone) => (
+							{microphones.map((microphone, index) => (
 								<option key={microphone.deviceId} value={microphone.deviceId}>
-									{microphone.label || "Microphone"}
+									{getDeviceLabel(microphone, index, "Microphone")}
 								</option>
 							))}
 						</select>
@@ -491,6 +620,16 @@ export function VoiceVideoSetting() {
 			</div>
 		</div>
 	);
+}
+
+function getDeviceLabel(
+	device: MediaDeviceInfo,
+	index: number,
+	fallbackType: "Camera" | "Microphone"
+) {
+	const trimmed = device.label?.trim();
+	if (trimmed) return trimmed;
+	return `${fallbackType} ${index + 1}`;
 }
 
 async function runPublishStatsTest(

--- a/src/components/VoiceVideoSetting/VoiceVideoSetting.tsx
+++ b/src/components/VoiceVideoSetting/VoiceVideoSetting.tsx
@@ -14,8 +14,6 @@ import {
 	type CallQualitySetting,
 	type ScreenShareQualitySetting,
 } from "../../utils/callQuality";
-import { useCameraPreview } from "./CameraPreview/useCameraPreview";
-import { CameraPreviewCard } from "./CameraPreview/CameraPreviewCard";
 
 interface PublishStats {
 	packetsLost: number;
@@ -78,20 +76,6 @@ export function VoiceVideoSetting() {
 
 		getDevices();
 	}, []);
-
-	const selectedCameraLabel =
-		cameras.find((camera) => camera.deviceId === selectedCameraId)?.label ||
-		(selectedCameraId === "default" ? "Default camera" : "Selected camera");
-	const {
-		status: cameraPreviewStatus,
-		error: cameraPreviewError,
-		videoElementRef: cameraPreviewVideoRef,
-	} = useCameraPreview({
-		selectedCameraId,
-		cameraQuality,
-		recommendation,
-		hasCameraDevices: !mediaDevicesReady || cameras.length > 0,
-	});
 
 	useEffect(() => {
 		const startAudio = async () => {
@@ -280,12 +264,6 @@ export function VoiceVideoSetting() {
 
 					<div className={styles["form-group"]}>
 						<label className={styles["label"]}>Camera Preview</label>
-						<CameraPreviewCard
-							status={cameraPreviewStatus}
-							error={cameraPreviewError}
-							selectedCameraLabel={selectedCameraLabel}
-							videoRef={cameraPreviewVideoRef}
-						/>
 					</div>
 
 					<div className={styles["form-group"]}>

--- a/src/hooks/useDismissibleLayer.ts
+++ b/src/hooks/useDismissibleLayer.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+
+interface UseDismissibleLayerParams {
+	isOpen: boolean;
+	onDismiss: () => void;
+	enabled?: boolean;
+}
+
+export function useDismissibleLayer({
+	isOpen,
+	onDismiss,
+	enabled = true,
+}: UseDismissibleLayerParams) {
+	useEffect(() => {
+		if (!enabled || !isOpen) return;
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				onDismiss();
+			}
+		};
+
+		const onWindowChange = () => {
+			onDismiss();
+		};
+
+		window.addEventListener("keydown", onKeyDown);
+		window.addEventListener("scroll", onWindowChange, true);
+		window.addEventListener("resize", onWindowChange);
+
+		return () => {
+			window.removeEventListener("keydown", onKeyDown);
+			window.removeEventListener("scroll", onWindowChange, true);
+			window.removeEventListener("resize", onWindowChange);
+		};
+	}, [enabled, isOpen, onDismiss]);
+}

--- a/src/store/slices/call.slice.ts
+++ b/src/store/slices/call.slice.ts
@@ -18,6 +18,7 @@ export interface CallState {
 	selectedScreenTrackSid: string | null;
 	presentationMode: CallPresentationMode;
 	isCallFocusMode: boolean;
+	isTheaterMode: boolean;
 }
 
 export const initialState: CallState = {
@@ -34,6 +35,7 @@ export const initialState: CallState = {
 	selectedScreenTrackSid: null,
 	presentationMode: "expanded",
 	isCallFocusMode: false,
+	isTheaterMode: false,
 }
 
 export const getToken = createAsyncThunk(
@@ -66,6 +68,7 @@ export const callSlice = createSlice({
 			previousState.selectedScreenTrackSid = null;
 			previousState.presentationMode = "expanded";
 			previousState.isCallFocusMode = false;
+			previousState.isTheaterMode = false;
 		},
 		incomingInvite: (previousState, action: PayloadAction<CallInviteEvent>) => {
 			previousState.status = "incoming_ringing";
@@ -79,6 +82,7 @@ export const callSlice = createSlice({
 			previousState.selectedScreenTrackSid = null;
 			previousState.presentationMode = "expanded";
 			previousState.isCallFocusMode = false;
+			previousState.isTheaterMode = false;
 		},
 		setConnecting: (previousState) => {
 			previousState.status = "connecting";
@@ -107,6 +111,7 @@ export const callSlice = createSlice({
 			previousState.presentationMode = action.payload;
 			if (action.payload !== "expanded") {
 				previousState.isCallFocusMode = false;
+				previousState.isTheaterMode = false;
 			}
 		},
 
@@ -118,8 +123,16 @@ export const callSlice = createSlice({
 		setCallFocusMode: (previousState, action: PayloadAction<boolean>) => {
 			if (action.payload) {
 				previousState.presentationMode = "expanded";
+				previousState.isTheaterMode = false;
 			}
 			previousState.isCallFocusMode = action.payload;
+		},
+		setTheaterMode: (previousState, action: PayloadAction<boolean>) => {
+			if (action.payload) {
+				previousState.presentationMode = "expanded";
+				previousState.isCallFocusMode = false;
+			}
+			previousState.isTheaterMode = action.payload;
 		}
 	},
 	extraReducers: builder => {

--- a/src/store/slices/device.slice.ts
+++ b/src/store/slices/device.slice.ts
@@ -3,7 +3,24 @@ import type {
 	CallQualityRecommendation,
 	CallQualitySetting,
 	NetworkQualityMetrics,
+	ScreenShareQualitySetting,
 } from "../../utils/callQuality";
+
+export type ParticipantAudioSource = "microphone" | "screenShareAudio";
+
+export interface ParticipantVolumePreference {
+	participantIdentity: string;
+	source: ParticipantAudioSource;
+	volume: number;
+}
+
+export interface ScreenShareRuntimeInfo {
+	requestedFps: number | null;
+	actualFps: number | null;
+	activePreset: string | null;
+	fallbackReason: string | null;
+	updatedAt: string | null;
+}
 
 export interface ConnectionTestResult {
 	status: "idle" | "running" | "succeeded" | "failed";
@@ -18,17 +35,72 @@ export interface DeviceState {
 	selectedCameraId: string;
 	selectedMicrophoneId: string;
 	cameraQuality: CallQualitySetting;
-	screenShareQuality: CallQualitySetting;
+	screenShareQuality: ScreenShareQualitySetting;
 	isNoiseSuppressionEnabled: boolean;
+	isEchoCancellationEnabled: boolean;
+	isAutoGainControlEnabled: boolean;
+	voiceActivityThreshold: number;
+	isAutoInputSensitivity: boolean;
+	participantVolumes: ParticipantVolumePreference[];
+	screenShareRuntime: ScreenShareRuntimeInfo;
 	connectionTestResult: ConnectionTestResult;
 }
 
+const DEVICE_PREFS_STORAGE_KEY = "device-preferences-v2";
+
+function loadStoredPreferences() {
+	try {
+		const raw = localStorage.getItem(DEVICE_PREFS_STORAGE_KEY);
+		if (!raw) return null;
+		return JSON.parse(raw) as Partial<DeviceState>;
+	} catch (error) {
+		console.error("Failed to parse device preferences", error);
+		return null;
+	}
+}
+
+function saveStoredPreferences(state: DeviceState) {
+	try {
+		localStorage.setItem(
+			DEVICE_PREFS_STORAGE_KEY,
+			JSON.stringify({
+				selectedCameraId: state.selectedCameraId,
+				selectedMicrophoneId: state.selectedMicrophoneId,
+				cameraQuality: state.cameraQuality,
+				screenShareQuality: state.screenShareQuality,
+				isNoiseSuppressionEnabled: state.isNoiseSuppressionEnabled,
+				isEchoCancellationEnabled: state.isEchoCancellationEnabled,
+				isAutoGainControlEnabled: state.isAutoGainControlEnabled,
+				voiceActivityThreshold: state.voiceActivityThreshold,
+				isAutoInputSensitivity: state.isAutoInputSensitivity,
+				participantVolumes: state.participantVolumes,
+			})
+		);
+	} catch (error) {
+		console.error("Failed to save device preferences", error);
+	}
+}
+
+const storedPrefs = loadStoredPreferences();
+
 const initialState: DeviceState = {
-	selectedCameraId: "default",
-	selectedMicrophoneId: "default",
-	cameraQuality: "high",
-	screenShareQuality: "medium",
-	isNoiseSuppressionEnabled: true,
+	selectedCameraId: storedPrefs?.selectedCameraId ?? "default",
+	selectedMicrophoneId: storedPrefs?.selectedMicrophoneId ?? "default",
+	cameraQuality: storedPrefs?.cameraQuality ?? "high",
+	screenShareQuality: storedPrefs?.screenShareQuality ?? "medium",
+	isNoiseSuppressionEnabled: storedPrefs?.isNoiseSuppressionEnabled ?? true,
+	isEchoCancellationEnabled: storedPrefs?.isEchoCancellationEnabled ?? true,
+	isAutoGainControlEnabled: storedPrefs?.isAutoGainControlEnabled ?? true,
+	voiceActivityThreshold: storedPrefs?.voiceActivityThreshold ?? 35,
+	isAutoInputSensitivity: storedPrefs?.isAutoInputSensitivity ?? true,
+	participantVolumes: storedPrefs?.participantVolumes ?? [],
+	screenShareRuntime: {
+		requestedFps: null,
+		actualFps: null,
+		activePreset: null,
+		fallbackReason: null,
+		updatedAt: null,
+	},
 	connectionTestResult: {
 		status: "idle",
 		summary: null,
@@ -45,18 +117,82 @@ export const deviceSlice = createSlice({
 	reducers: {
 		setCamera: (previousState, action: PayloadAction<string>) => {
 			previousState.selectedCameraId = action.payload;
+			saveStoredPreferences(previousState);
 		},
 		setMicrophone: (previousState, action: PayloadAction<string>) => {
 			previousState.selectedMicrophoneId = action.payload;
+			saveStoredPreferences(previousState);
 		},
 		setCameraQuality: (previousState, action: PayloadAction<CallQualitySetting>) => {
 			previousState.cameraQuality = action.payload;
+			saveStoredPreferences(previousState);
 		},
-		setScreenShareQuality: (previousState, action: PayloadAction<CallQualitySetting>) => {
+		setScreenShareQuality: (previousState, action: PayloadAction<ScreenShareQualitySetting>) => {
 			previousState.screenShareQuality = action.payload;
+			saveStoredPreferences(previousState);
 		},
 		setNoiseSuppression: (state, action: PayloadAction<boolean>) => {
 			state.isNoiseSuppressionEnabled = action.payload;
+			saveStoredPreferences(state);
+		},
+		setEchoCancellation: (state, action: PayloadAction<boolean>) => {
+			state.isEchoCancellationEnabled = action.payload;
+			saveStoredPreferences(state);
+		},
+		setAutoGainControl: (state, action: PayloadAction<boolean>) => {
+			state.isAutoGainControlEnabled = action.payload;
+			saveStoredPreferences(state);
+		},
+		setVoiceActivityThreshold: (state, action: PayloadAction<number>) => {
+			state.voiceActivityThreshold = action.payload;
+			saveStoredPreferences(state);
+		},
+		setAutoInputSensitivity: (state, action: PayloadAction<boolean>) => {
+			state.isAutoInputSensitivity = action.payload;
+			saveStoredPreferences(state);
+		},
+		setParticipantVolume: (
+			state,
+			action: PayloadAction<ParticipantVolumePreference>
+		) => {
+			const { participantIdentity, source, volume } = action.payload;
+			const existing = state.participantVolumes.find(
+				(item) =>
+					item.participantIdentity === participantIdentity && item.source === source
+			);
+			if (existing) {
+				existing.volume = volume;
+			} else {
+				state.participantVolumes.push({ participantIdentity, source, volume });
+			}
+			saveStoredPreferences(state);
+		},
+		resetParticipantVolume: (
+			state,
+			action: PayloadAction<{ participantIdentity: string; source: ParticipantAudioSource }>
+		) => {
+			state.participantVolumes = state.participantVolumes.filter(
+				(item) =>
+					!(
+						item.participantIdentity === action.payload.participantIdentity &&
+						item.source === action.payload.source
+					)
+			);
+			saveStoredPreferences(state);
+		},
+		setScreenShareRuntimeInfo: (
+			state,
+			action: PayloadAction<{
+				requestedFps: number | null;
+				actualFps: number | null;
+				activePreset: string | null;
+				fallbackReason: string | null;
+			}>
+		) => {
+			state.screenShareRuntime = {
+				...action.payload,
+				updatedAt: new Date().toISOString(),
+			};
 		},
 		setConnectionTestRunning: (state) => {
 			state.connectionTestResult.status = "running";
@@ -91,10 +227,12 @@ export const deviceSlice = createSlice({
 
 			state.cameraQuality = recommendation.cameraQuality;
 			state.screenShareQuality = recommendation.screenShareQuality;
+			saveStoredPreferences(state);
 		},
 		useAutoQuality: (state) => {
 			state.cameraQuality = "auto";
 			state.screenShareQuality = "auto";
+			saveStoredPreferences(state);
 		}
 	}
 })

--- a/src/utils/callQuality.ts
+++ b/src/utils/callQuality.ts
@@ -7,6 +7,8 @@ import type {
 
 export type ManualCallQuality = "low" | "medium" | "high";
 export type CallQualitySetting = "auto" | ManualCallQuality;
+export type ScreenShareManualQuality = ManualCallQuality | "game60" | "game120";
+export type ScreenShareQualitySetting = "auto" | ScreenShareManualQuality;
 export type CallMediaKind = "camera" | "screenShare";
 
 export interface CallQualityPreset {
@@ -19,9 +21,17 @@ export interface CallQualityPreset {
 	description: string;
 }
 
+export interface ScreenShareQualityPreset
+	extends Omit<CallQualityPreset, "value"> {
+	value: ScreenShareManualQuality;
+	warning?: string;
+	bandwidthHint?: string;
+	isExperimental?: boolean;
+}
+
 export interface CallQualityRecommendation {
 	cameraQuality: ManualCallQuality;
-	screenShareQuality: ManualCallQuality;
+	screenShareQuality: ScreenShareManualQuality;
 }
 
 export interface NetworkQualityMetrics {
@@ -63,7 +73,10 @@ export const CAMERA_QUALITY_PRESETS: Record<ManualCallQuality, CallQualityPreset
 	},
 };
 
-export const SCREEN_SHARE_QUALITY_PRESETS: Record<ManualCallQuality, CallQualityPreset> = {
+export const SCREEN_SHARE_QUALITY_PRESETS: Record<
+	ScreenShareManualQuality,
+	ScreenShareQualityPreset
+> = {
 	low: {
 		value: "low",
 		label: "Low",
@@ -90,27 +103,66 @@ export const SCREEN_SHARE_QUALITY_PRESETS: Record<ManualCallQuality, CallQuality
 		frameRate: 30,
 		maxBitrate: 5_000_000,
 		description: "1080p, smoother screen motion",
-	}
+	},
+	game60: {
+		value: "game60",
+		label: "Gaming 1080p60",
+		width: 1920,
+		height: 1080,
+		frameRate: 60,
+		maxBitrate: 8_000_000,
+		description: "1080p60, low-latency motion-focused stream",
+		bandwidthHint: "Needs stable upload around 8+ Mbps",
+	},
+	game120: {
+		value: "game120",
+		label: "Gaming 1080p120 Experimental",
+		width: 1920,
+		height: 1080,
+		frameRate: 120,
+		maxBitrate: 12_000_000,
+		description: "1080p120 best effort for high-motion game streams",
+		warning:
+			"Experimental. Requires strong upload and browser/source support.",
+		bandwidthHint: "Needs very stable upload around 12+ Mbps",
+		isExperimental: true,
+	},
 };
 
 export const DEFAULT_AUTO_QUALITY: ManualCallQuality = "medium";
 
-export function getQualityPreset(kind: CallMediaKind, quality: ManualCallQuality) {
+export function getQualityPreset(
+	kind: "camera",
+	quality: ManualCallQuality
+): CallQualityPreset;
+export function getQualityPreset(
+	kind: "screenShare",
+	quality: ScreenShareManualQuality
+): ScreenShareQualityPreset;
+export function getQualityPreset(
+	kind: CallMediaKind,
+	quality: ManualCallQuality | ScreenShareManualQuality
+) {
 	return kind === "camera"
-		? CAMERA_QUALITY_PRESETS[quality]
-		: SCREEN_SHARE_QUALITY_PRESETS[quality];
+		? CAMERA_QUALITY_PRESETS[quality as ManualCallQuality]
+		: SCREEN_SHARE_QUALITY_PRESETS[quality as ScreenShareManualQuality];
 }
 
 export function resolveQualitySetting(
-	kind: CallMediaKind,
+	kind: "camera",
 	setting: CallQualitySetting,
 	recommendation?: CallQualityRecommendation | null
 ): ManualCallQuality {
 	if (setting !== "auto") return setting;
 
-	if (kind === "camera") {
-		return recommendation?.cameraQuality ?? DEFAULT_AUTO_QUALITY;
-	}
+	return recommendation?.cameraQuality ?? DEFAULT_AUTO_QUALITY;
+}
+
+export function resolveScreenShareQualitySetting(
+	setting: ScreenShareQualitySetting,
+	recommendation?: CallQualityRecommendation | null
+): ScreenShareManualQuality {
+	if (setting !== "auto") return setting;
 
 	return recommendation?.screenShareQuality ?? DEFAULT_AUTO_QUALITY;
 }
@@ -131,7 +183,7 @@ export function getCameraCaptureOptions(
 }
 
 export function getScreenShareCaptureOptions(
-	preset: CallQualityPreset
+	preset: ScreenShareQualityPreset
 ): ScreenShareCaptureOptions {
 	return {
 		audio: true,
@@ -152,9 +204,12 @@ export function getCameraPublishOptions(preset: CallQualityPreset): TrackPublish
 	};
 }
 
-export function getScreenSharePublishOptions(preset: CallQualityPreset): TrackPublishOptions {
+export function getScreenSharePublishOptions(
+	preset: ScreenShareQualityPreset
+): TrackPublishOptions {
 	return {
-		degradationPreference: "maintain-resolution",
+		degradationPreference:
+			preset.frameRate >= 60 ? "maintain-framerate" : "maintain-resolution",
 		screenShareEncoding: getVideoEncoding(preset, "high"),
 	};
 }


### PR DESCRIPTION
### Motivation

- Add per-user volume controls and persist user audio preferences locally to improve in-call mixing without backend changes. 
- Expose richer screen-share quality presets (1080p60 and experimental 1080p120) and implement runtime fallback logic when the browser/source cannot deliver requested FPS. 
- Give users more microphone capture knobs (echo cancellation, auto gain) and configurable input-sensitivity to make speaking detection and local monitoring more reliable.

### Description

- Extend device state and persistence: `src/store/slices/device.slice.ts` adds new fields (`participantVolumes`, `isEchoCancellationEnabled`, `isAutoGainControlEnabled`, `voiceActivityThreshold`, `isAutoInputSensitivity`, `screenShareRuntime`), actions to set/reset participant volume and runtime info, and localStorage persistence under `device-preferences-v2`.
- Add per-user audio UI and wiring: `CallUi.tsx` introduces the `Audio Mix` panel with sliders and reset buttons and dispatches `deviceActions.setParticipantVolume` / `resetParticipantVolume`; styles added in `CallUi.module.css`.
- Apply per-user volume to playback: `CallAudioLayer.tsx` looks up `device.participantVolumes` and sets remote audio track volume via `RemoteAudioTrack.setVolume` for non-local tracks and maps track sources using `toAudioSource`.
- Improve speaking detection and input-sensitivity: `MiniSpeakingStatus.tsx` and `CallParticipantTile.tsx` use `voiceActivityThreshold` and `isAutoInputSensitivity` to decide local speaking based on `participant.audioLevel` while preserving remote `participant.isSpeaking` behavior.
- Microphone capture options and settings UI: `useMicrophoneCaptureOptions.ts` and `VoiceVideoSetting.tsx` add toggles for echo cancellation and auto gain control and wire them into `getUserMedia` constraints and saved device prefs; `VoiceVideoSetting` also exposes the new input sensitivity control and shows screen-share runtime info.
- Screen-share quality and runtime fallback: `src/utils/callQuality.ts` introduces `game60`/`game120` presets, new types for screen-share quality, and updated publish/capture options; `CallQualityController.tsx` applies gaming presets, reads `track.getSourceTrackSettings().frameRate`, implements fallback logic (fallback to `game60` or `high` for `game120`), updates sender encoding, and dispatches runtime info via `deviceActions.setScreenShareRuntimeInfo`.
- Misc: update doc `docs/call-domain-notes.md` with new presets and architectures, small CSS additions, and various wiring adjustments across components to consume the new device state.

### Testing

- Ran the project type-check (`tsc --noEmit`) and it completed successfully. 
- Ran the unit test suite (`yarn test`) and the tests passed. 
- Ran lint (`yarn lint`) and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee18df4e38832e8c78f6f5af8cbffd)