### PR TITLE
Add active room call banner and join flow (preserve active calls after decline)

### DIFF
--- a/src/api/callApi.ts
+++ b/src/api/callApi.ts
@@ -6,4 +6,10 @@ import type { RestoreCallSessionResponse } from "./interfaces/RestoreCallSession
 export const callApi: CallApiInterface = {
 	getCallToken: (callId: number) => api.post<CallTokenDto>(`/calls/${callId}/token`),
 	restoreCallSession: () => api.get<RestoreCallSessionResponse>("/calls/restore"),
+	getActiveCallByRoomId: (roomId: number) => api.get(`/rooms/${roomId}/active-call`),
+	joinCall: (dto) => api.post("/calls/join", dto),
+	acceptCall: (dto) => api.post("/calls/accept", dto),
+	declineCall: (dto) => api.post("/calls/decline", dto),
+	leaveCall: (dto) => api.post("/calls/leave", dto),
+	endCall: (dto) => api.post("/calls/end", dto),
 };

--- a/src/api/interfaces/ActiveCallResponse.ts
+++ b/src/api/interfaces/ActiveCallResponse.ts
@@ -2,20 +2,19 @@ import type { CallSessionStatus } from "../../entities/callSession";
 import type { RoomType } from "../../entities/room";
 import type { CallParticipantResponse } from "./CallParticipantResponse";
 
-
 export interface ActiveCallResponse {
 	callId: number;
 	chatRoomId: number;
 	roomId: number;
-	roomType: RoomType
+	roomType: RoomType;
 	status: CallSessionStatus;
 	liveKitRoomName: string;
 	hostUsername: string;
 	callerUsername: string;
 	callType: string;
-	participantsCount: number;
+	participantsCount?: number;
 	participants: CallParticipantResponse[];
-	startedAt: string;
-	activatedAt: string;
-	createAt: string
+	startedAt: string | null;
+	activatedAt: string | null;
+	createAt: string | null;
 }

--- a/src/api/interfaces/CallApiInterface.ts
+++ b/src/api/interfaces/CallApiInterface.ts
@@ -1,8 +1,16 @@
 import type { AxiosResponse } from "axios";
 import type { CallTokenDto } from "./CallTokenDto";
 import type { RestoreCallSessionResponse } from "./RestoreCallSessionResponse";
+import type { ActiveCallResponse } from "./ActiveCallResponse";
+import type { AcceptCallDto, DeclineCallDto, EndCallDto, JoinCallDto, LeaveCallDto } from "./CallDtos";
 
 export interface CallApiInterface {
 	getCallToken: (callId: number) => Promise<AxiosResponse<CallTokenDto>>;
-	restoreCallSession: () => Promise<AxiosResponse<RestoreCallSessionResponse>>
+	restoreCallSession: () => Promise<AxiosResponse<RestoreCallSessionResponse>>;
+	getActiveCallByRoomId: (roomId: number) => Promise<AxiosResponse<ActiveCallResponse | null>>;
+	joinCall: (dto: JoinCallDto) => Promise<AxiosResponse<ActiveCallResponse>>;
+	acceptCall: (dto: AcceptCallDto) => Promise<AxiosResponse<ActiveCallResponse>>;
+	declineCall: (dto: DeclineCallDto) => Promise<AxiosResponse<unknown>>;
+	leaveCall: (dto: LeaveCallDto) => Promise<AxiosResponse<unknown>>;
+	endCall: (dto: EndCallDto) => Promise<AxiosResponse<unknown>>;
 }

--- a/src/api/interfaces/CallDtos.ts
+++ b/src/api/interfaces/CallDtos.ts
@@ -1,0 +1,30 @@
+import type { RoomType } from "../../entities/room";
+import type { CallParticipantStatus } from "./CallParticipantResponse";
+import type { CallSessionStatus } from "../../entities/callSession";
+
+export interface JoinCallDto {
+	callId?: number | null;
+	chatRoomId?: number | null;
+}
+
+export interface AcceptCallDto {
+	callId?: number | null;
+	chatRoomId?: number | null;
+}
+
+export interface DeclineCallDto {
+	callId?: number | null;
+	chatRoomId?: number | null;
+}
+
+export interface LeaveCallDto {
+	callId?: number | null;
+	chatRoomId?: number | null;
+}
+
+export interface EndCallDto {
+	callId?: number | null;
+	chatRoomId?: number | null;
+}
+
+export type { CallParticipantStatus, CallSessionStatus, RoomType };

--- a/src/api/interfaces/CallParticipantResponse.ts
+++ b/src/api/interfaces/CallParticipantResponse.ts
@@ -1,13 +1,12 @@
-
-export type CallParticipantStatus = "RINGING" | "ACCEPTED" | "JOINED" | "DECLINED" | "LEFT"
+export type CallParticipantStatus = "RINGING" | "ACCEPTED" | "JOINED" | "DECLINED" | "LEFT";
 
 export interface CallParticipantResponse {
-	userId: string;
+	userId: number;
 	username: string;
-	displayName: string;
-	avatarUrl: string;
+	displayName: string | null;
+	avatarUrl: string | null;
 	status: CallParticipantStatus;
-	joinedAt: string;
-	acceptedAt: string;
-	leftAt: string;
+	joinedAt: string | null;
+	acceptedAt: string | null;
+	leftAt: string | null;
 }

--- a/src/components/RoomActiveCallBanner/RoomActiveCallBanner.module.css
+++ b/src/components/RoomActiveCallBanner/RoomActiveCallBanner.module.css
@@ -1,0 +1,47 @@
+.banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin: 12px 16px 0;
+	padding: 12px 14px;
+	border: 1px solid rgba(88, 166, 255, 0.35);
+	border-radius: 12px;
+	background: rgba(88, 166, 255, 0.12);
+	color: var(--text-primary);
+}
+
+.content {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.title {
+	font-weight: 700;
+}
+
+.meta,
+.error {
+	font-size: 13px;
+	color: var(--text-secondary);
+}
+
+.error {
+	color: #ff8a8a;
+}
+
+.join-button {
+	border: 0;
+	border-radius: 999px;
+	padding: 8px 18px;
+	background: #2f81f7;
+	color: white;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.join-button:disabled {
+	opacity: 0.7;
+	cursor: not-allowed;
+}

--- a/src/components/RoomActiveCallBanner/RoomActiveCallBanner.tsx
+++ b/src/components/RoomActiveCallBanner/RoomActiveCallBanner.tsx
@@ -1,0 +1,62 @@
+import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "../../store/store";
+import { activeCallActions, joinActiveCall } from "../../store/slices/activeCall.slice";
+import { callActions, getCallToken } from "../../store/slices/call.slice";
+import styles from "./RoomActiveCallBanner.module.css";
+
+interface RoomActiveCallBannerProps {
+	roomId: number | null;
+}
+
+export function RoomActiveCallBanner({ roomId }: RoomActiveCallBannerProps) {
+	const dispatch = useDispatch<AppDispatch>();
+	const activeCall = useSelector((s: RootState) => roomId ? s.activeCall.activeCallsByRoomId[roomId] : null);
+	const joinStatus = useSelector((s: RootState) => s.activeCall.joinStatus);
+	const joinError = useSelector((s: RootState) => s.activeCall.joinError);
+	const currentCallId = useSelector((s: RootState) => s.call.callId ?? s.activeCall.currentCallId);
+	const currentUser = useSelector((s: RootState) => s.user.myUser);
+
+	if (!activeCall) return null;
+
+	const currentParticipant = activeCall.participants.find((participant) => participant.username === currentUser?.username);
+	const isCurrentUserInThisCall = currentCallId === activeCall.callId
+		&& (currentParticipant?.status === "ACCEPTED" || currentParticipant?.status === "JOINED");
+	const isActiveStatus = activeCall.status === "ACTIVE" || activeCall.status === "RINGING";
+	const shouldShowBanner = isActiveStatus && !isCurrentUserInThisCall
+		&& (activeCall.roomType === "GROUP" || activeCall.roomType === "PRIVATE");
+
+	if (!shouldShowBanner) return null;
+
+	const handleJoin = async () => {
+		try {
+			const joinedCall = await dispatch(joinActiveCall({ callId: activeCall.callId, chatRoomId: activeCall.chatRoomId })).unwrap();
+			dispatch(activeCallActions.setCurrentCall({ callId: joinedCall.callId, roomId: joinedCall.chatRoomId }));
+			dispatch(callActions.prepareJoinedCall({
+				callId: joinedCall.callId,
+				chatRoomId: joinedCall.chatRoomId,
+				roomType: joinedCall.roomType,
+				livekitRoomName: joinedCall.liveKitRoomName,
+				callerUsername: joinedCall.callerUsername,
+				hostUsername: joinedCall.hostUsername,
+			}));
+			dispatch(getCallToken(joinedCall.callId));
+		} catch {
+			// joinError is stored in Redux and rendered in the banner.
+		}
+	};
+
+	return (
+		<div className={styles["banner"]}>
+			<div className={styles["content"]}>
+				<span className={styles["title"]}>{activeCall.roomType === "GROUP" ? "В комнате идёт звонок" : "Идёт звонок"}</span>
+				{typeof activeCall.participantsCount === "number" && (
+					<span className={styles["meta"]}>Участников: {activeCall.participantsCount}</span>
+				)}
+				{joinError && <span className={styles["error"]}>{joinError}</span>}
+			</div>
+			<button className={styles["join-button"]} disabled={joinStatus === "loading"} onClick={handleJoin}>
+				{joinStatus === "loading" ? "Входим..." : "Войти"}
+			</button>
+		</div>
+	);
+}

--- a/src/hooks/useActiveRoomCall.ts
+++ b/src/hooks/useActiveRoomCall.ts
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import type { AppDispatch } from "../store/store";
+import { getActiveCall } from "../store/slices/activeCall.slice";
+
+export function useActiveRoomCall(roomId: number | null) {
+	const dispatch = useDispatch<AppDispatch>();
+
+	useEffect(() => {
+		if (!roomId) return;
+		dispatch(getActiveCall(roomId));
+	}, [dispatch, roomId]);
+}

--- a/src/pages/DmChat/DmChat.tsx
+++ b/src/pages/DmChat/DmChat.tsx
@@ -12,6 +12,8 @@ import { Phone, Send, SettingsIcon, X } from "lucide-react";
 import { RoomSettingModal } from "../../components/RoomSettingModal/RoomSettingModal";
 import { StringToColor } from "../../utils/stringHelpers";
 import { toastActions } from "../../store/slices/toast.slice";
+import { useActiveRoomCall } from "../../hooks/useActiveRoomCall";
+import { RoomActiveCallBanner } from "../../components/RoomActiveCallBanner/RoomActiveCallBanner";
 
 export function DmChat() {
 	const navigate = useNavigate();
@@ -23,7 +25,6 @@ export function DmChat() {
 	const usersById = useSelector((s: RootState) => s.users.byId);
 	const { replyTarget } = useSelector((s: RootState) => s.message);
 	const wsStatus = useSelector((s: RootState) => s.websocket.status);
-	const activeCall = useSelector((s: RootState) => s.activeCall.activeCall)
 	const callStatus = useSelector((s: RootState) => s.call.status);
 
 	const [text, setText] = useState("");
@@ -32,6 +33,8 @@ export function DmChat() {
 	const roomIdParam = searchParams.get("roomId");
 	const parsedRoomId = roomIdParam ? Number(roomIdParam) : null;
 	const roomId = parsedRoomId !== null && !Number.isNaN(parsedRoomId) ? parsedRoomId : null;
+
+	useActiveRoomCall(roomId);
 
 	useEffect(() => {
 		if (!roomId) {
@@ -187,6 +190,8 @@ export function DmChat() {
 					</button>
 				</div>
 			</div>
+
+			<RoomActiveCallBanner roomId={roomId} />
 
 			<RoomSettingModal
 				isOpen={isRoomSettingOpen}

--- a/src/store/interfaces/callEvents.interface.ts
+++ b/src/store/interfaces/callEvents.interface.ts
@@ -8,14 +8,18 @@ export interface BaseCallEvent {
 	roomId?: number;
 	roomType?: CallRoomType;
 	liveKitRoomName?: string;
+	livekitRoomName?: string;
 	callerUsername?: string;
 	hostUsername?: string;
 	participantUsername?: string;
 	callType?: "audio" | "video" | string;
 	occurredAt?: string;
 	timestamp?: string;
-	callStatus?: string;
-	participantStatus?: string;
+	callStatus?: "RINGING" | "ACTIVE" | "ENDED";
+	participantStatus?: "RINGING" | "ACCEPTED" | "JOINED" | "DECLINED" | "LEFT";
+	endReason?: string | null;
+	participantsCount?: number;
+	callRoomType?: CallRoomType;
 	fromUser?: string;
 }
 

--- a/src/store/middlewares/websocket.middleware.ts
+++ b/src/store/middlewares/websocket.middleware.ts
@@ -99,6 +99,7 @@ export const websocketMiddleware: Middleware<{}, RootState, AppDispatch> = (stor
 						console.log(data)
 
 						storeApi.dispatch(callActions.applyCallEvent(data));
+						storeApi.dispatch(activeCallActions.handleCallEvent(data));
 						
 						const callId = data.callId;
 						if (!callId) return;
@@ -125,9 +126,6 @@ export const websocketMiddleware: Middleware<{}, RootState, AppDispatch> = (stor
 							storeApi.dispatch(getCallToken(callId));
 						}
 
-						if (data.type === "CALL_ENDED") {
-							storeApi.dispatch(activeCallActions.clearCall());	
-						}
 
 						if (data.type === "CALL_PARTICIPANT_JOINED") {
 							const state = storeApi.getState();
@@ -455,7 +453,6 @@ export const websocketMiddleware: Middleware<{}, RootState, AppDispatch> = (stor
 					})
 				})
 
-				storeApi.dispatch(activeCallActions.clearCall());
 				break;
 			}
 
@@ -473,7 +470,6 @@ export const websocketMiddleware: Middleware<{}, RootState, AppDispatch> = (stor
 					})
 				})
 
-				storeApi.dispatch(activeCallActions.clearCall());
 				break;
 			}
 
@@ -491,7 +487,6 @@ export const websocketMiddleware: Middleware<{}, RootState, AppDispatch> = (stor
 					})
 				})
 
-				storeApi.dispatch(activeCallActions.clearCall());
 				break;
 			}
 

--- a/src/store/slices/activeCall.slice.ts
+++ b/src/store/slices/activeCall.slice.ts
@@ -1,50 +1,187 @@
 import { createAsyncThunk, createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { callApi } from "../../api/callApi";
 import type { ActiveCallResponse } from "../../api/interfaces/ActiveCallResponse";
-import { roomApi } from "../../api/roomApi";
-
+import type { JoinCallDto } from "../../api/interfaces/CallDtos";
+import type { CallParticipantStatus } from "../../api/interfaces/CallParticipantResponse";
+import type { BaseCallEvent } from "../interfaces/callEvents.interface";
 
 export interface ActiveCallState {
-	activeCall: null | ActiveCallResponse
-	error: null | string;
+	activeCallsByRoomId: Record<number, ActiveCallResponse>;
+	incomingCall: BaseCallEvent | null;
+	currentCallId: number | null;
+	currentRoomId: number | null;
+	status: "idle" | "ringing" | "connecting" | "in-call" | "ended";
+	error: string | null;
+	joinStatus: "idle" | "loading" | "succeeded" | "failed";
+	joinError: string | null;
 }
 
 export const initialState: ActiveCallState = {
-	activeCall: null,
-	error: null
-}
+	activeCallsByRoomId: {},
+	incomingCall: null,
+	currentCallId: null,
+	currentRoomId: null,
+	status: "idle",
+	error: null,
+	joinStatus: "idle",
+	joinError: null,
+};
+
+const eventToActiveCall = (event: BaseCallEvent): ActiveCallResponse | null => {
+	const chatRoomId = event.chatRoomId ?? event.roomId;
+	if (!event.callId || !chatRoomId || !event.roomType || !event.liveKitRoomName) return null;
+
+	return {
+		callId: event.callId,
+		chatRoomId,
+		roomId: event.roomId ?? chatRoomId,
+		roomType: event.roomType,
+		status: event.callStatus === "ENDED" ? "ENDED" : event.callStatus === "ACTIVE" ? "ACTIVE" : "RINGING",
+		liveKitRoomName: event.liveKitRoomName,
+		hostUsername: event.hostUsername ?? "",
+		callerUsername: event.callerUsername ?? event.fromUser ?? "",
+		callType: event.callType ?? "audio",
+		participantsCount: event.participantsCount,
+		participants: event.participantUsername
+			? [{
+				userId: 0,
+				username: event.participantUsername,
+				displayName: null,
+				avatarUrl: null,
+				status: event.participantStatus ?? "RINGING",
+				joinedAt: null,
+				acceptedAt: null,
+				leftAt: null,
+			}]
+			: [],
+		startedAt: null,
+		activatedAt: null,
+		createAt: null,
+	};
+};
 
 export const getActiveCall = createAsyncThunk("activeCall/getActiveCall", async (roomId: number, thunkAPI) => {
 	try {
-		const { data } = await roomApi.getActiveCall({ roomId });
-		return data;
-	} catch(e: any) {
+		const { data } = await callApi.getActiveCallByRoomId(roomId);
+		return { roomId, activeCall: data };
+	} catch (e: any) {
+		if (e?.response?.status === 404) return { roomId, activeCall: null };
 		return thunkAPI.rejectWithValue(e?.message ?? "Failed to get active call");
 	}
-})
+});
+
+export const joinActiveCall = createAsyncThunk("activeCall/joinActiveCall", async (dto: JoinCallDto, thunkAPI) => {
+	try {
+		const { data } = await callApi.joinCall(dto);
+		return data;
+	} catch (e: any) {
+		return thunkAPI.rejectWithValue(e?.message ?? "Failed to join call");
+	}
+});
 
 export const activeCallSlice = createSlice({
 	name: "activeCall",
 	initialState,
 	reducers: {
-		clearCall: (previosState) => {
-			previosState.activeCall = null;
-		}
+		setActiveCallForRoom: (state, action: PayloadAction<ActiveCallResponse>) => {
+			state.activeCallsByRoomId[action.payload.chatRoomId] = action.payload;
+			state.error = null;
+		},
+		removeActiveCallForRoom: (state, action: PayloadAction<number>) => {
+			delete state.activeCallsByRoomId[action.payload];
+		},
+		clearActiveCallForRoom: (state, action: PayloadAction<number>) => {
+			delete state.activeCallsByRoomId[action.payload];
+		},
+		clearCall: (state) => {
+			state.activeCallsByRoomId = {};
+		},
+		setIncomingCall: (state, action: PayloadAction<BaseCallEvent>) => {
+			state.incomingCall = action.payload;
+			state.status = "ringing";
+		},
+		clearIncomingCall: (state) => {
+			state.incomingCall = null;
+		},
+		setCurrentCall: (state, action: PayloadAction<{ callId: number | null; roomId: number | null }>) => {
+			state.currentCallId = action.payload.callId;
+			state.currentRoomId = action.payload.roomId;
+			state.status = action.payload.callId ? "in-call" : "idle";
+		},
+		updateParticipantStatusInActiveCall: (state, action: PayloadAction<{ roomId: number; username?: string | null; status: CallParticipantStatus }>) => {
+			const activeCall = state.activeCallsByRoomId[action.payload.roomId];
+			if (!activeCall || !action.payload.username) return;
+			const participant = activeCall.participants.find((p) => p.username === action.payload.username);
+			if (participant) participant.status = action.payload.status;
+		},
+		handleCallEvent: (state, action: PayloadAction<BaseCallEvent>) => {
+			const event = action.payload;
+			const roomId = event.chatRoomId ?? event.roomId;
+			if (!roomId) return;
+
+			if (event.type === "CALL_ENDED") {
+				delete state.activeCallsByRoomId[roomId];
+				if (state.incomingCall?.callId === event.callId) state.incomingCall = null;
+				if (state.currentCallId === event.callId) state.status = "ended";
+				return;
+			}
+
+			if (event.type === "CALL_INVITE" || event.type === "CALL_STARTED") {
+				const activeCall = eventToActiveCall(event);
+				if (activeCall) state.activeCallsByRoomId[roomId] = activeCall;
+				if (event.type === "CALL_INVITE") state.incomingCall = event;
+				return;
+			}
+
+			const statusByType: Partial<Record<string, CallParticipantStatus>> = {
+				CALL_ACCEPT: "ACCEPTED",
+				CALL_ACCEPTED: "ACCEPTED",
+				CALL_PARTICIPANT_JOINED: "JOINED",
+				CALL_PARTICIPANT_DECLINED: "DECLINED",
+				CALL_DECLINE: "DECLINED",
+				CALL_DECLINED: "DECLINED",
+				CALL_PARTICIPANT_LEFT: "LEFT",
+			};
+
+			const participantStatus = statusByType[event.type];
+			const activeCall = state.activeCallsByRoomId[roomId];
+			if (activeCall && event.callStatus === "ACTIVE") activeCall.status = "ACTIVE";
+			if (participantStatus && activeCall && event.participantUsername) {
+				const participant = activeCall.participants.find((p) => p.username === event.participantUsername);
+				if (participant) participant.status = participantStatus;
+			}
+		},
 	},
 	extraReducers: (builder) => {
 		builder
 			.addCase(getActiveCall.rejected, (state, action) => {
 				state.error = typeof action.payload === "string" ? action.payload : "Failed to get active call";
 			})
-			.addCase(getActiveCall.fulfilled, (state, action: PayloadAction<ActiveCallResponse | "">) => {
-				if (action.payload !== "") {
-					state.activeCall = action.payload;
+			.addCase(getActiveCall.fulfilled, (state, action: PayloadAction<{ roomId: number; activeCall: ActiveCallResponse | null }>) => {
+				if (action.payload.activeCall) {
+					state.activeCallsByRoomId[action.payload.roomId] = action.payload.activeCall;
 				} else {
-					state.activeCall = null;
+					delete state.activeCallsByRoomId[action.payload.roomId];
 				}
 				state.error = null;
 			})
-	}
-})
+			.addCase(joinActiveCall.pending, (state) => {
+				state.joinStatus = "loading";
+				state.joinError = null;
+			})
+			.addCase(joinActiveCall.fulfilled, (state, action: PayloadAction<ActiveCallResponse>) => {
+				state.activeCallsByRoomId[action.payload.chatRoomId] = action.payload;
+				state.currentCallId = action.payload.callId;
+				state.currentRoomId = action.payload.chatRoomId;
+				state.status = "connecting";
+				state.joinStatus = "succeeded";
+			})
+			.addCase(joinActiveCall.rejected, (state, action) => {
+				state.joinStatus = "failed";
+				state.joinError = typeof action.payload === "string" ? action.payload : "Failed to join call";
+			});
+	},
+});
 
 export default activeCallSlice.reducer;
 export const activeCallActions = activeCallSlice.actions;

--- a/src/store/slices/call.slice.ts
+++ b/src/store/slices/call.slice.ts
@@ -148,6 +148,18 @@ export const callSlice = createSlice({
 		markAcceptedHandled: (state, action: PayloadAction<number>) => {
 			state.lastAcceptedCallId = action.payload;
 		},
+		prepareJoinedCall: (state, action: PayloadAction<{ callId: number; chatRoomId: number; roomType: CallRoomType; livekitRoomName: string; callerUsername: string; hostUsername: string }>) => {
+			state.status = "connecting";
+			state.direction = null;
+			state.callId = action.payload.callId;
+			state.chatRoomId = action.payload.chatRoomId;
+			state.roomType = action.payload.roomType;
+			state.livekitRoomName = action.payload.livekitRoomName;
+			state.callerUsername = action.payload.callerUsername;
+			state.hostUsername = action.payload.hostUsername;
+			state.error = null;
+			state.presentationMode = "expanded";
+		},
 		leaveCallLocally: (state) => {
 			resetCallState(state, "ended");
 		},


### PR DESCRIPTION
### Motivation
- Enable users to join an ongoing room call (GROUP or PRIVATE) even after previously declining the invite and show a persistent active-call banner in the room. 
- Keep active-call state separate from incoming invite modal so `decline` only hides the modal and does not remove the active call unless backend reports it ended. 
- Reuse existing LiveKit token flow and existing websocket-based call mechanics when entering a call.

### Description
- Added typed DTOs and API client methods in `src/api/*` to support `getActiveCallByRoomId`, `joinCall`, `acceptCall`, `declineCall`, `leaveCall`, and `endCall` while reusing `getCallToken` (`src/api/interfaces/CallDtos.ts`, `src/api/callApi.ts`, `src/api/interfaces/CallApiInterface.ts`).
- Implemented a new `activeCall` Redux feature that tracks `activeCallsByRoomId`, `incomingCall`, current call, join state and participant statuses, and added reducers/actions including `setActiveCallForRoom`, `removeActiveCallForRoom`, `setIncomingCall`, `clearIncomingCall`, `updateParticipantStatusInActiveCall`, and `handleCallEvent` (`src/store/slices/activeCall.slice.ts`).
- Updated websocket middleware to route incoming call events into the new active-call handler and stop clearing active-call state on local `decline/leave/end` commands so the banner remains until `CALL_ENDED` or fetch returns `null/404` (`src/store/middlewares/websocket.middleware.ts`).
- Added `RoomActiveCallBanner` UI component and `useActiveRoomCall(roomId)` hook to fetch active calls on room open and show banner text/button for `GROUP` and `PRIVATE` rooms, with a `Join` button that performs `joinCall` then requests LiveKit token (`getCallToken`) and prepares call state with a new `call.prepareJoinedCall` reducer (`src/components/RoomActiveCallBanner/*`, `src/hooks/useActiveRoomCall.ts`, `src/store/slices/call.slice.ts`).
- Integrated banner and hook into existing DM room page so any open room triggers `getActiveCallByRoomId(roomId)` and conditionally shows the banner when the call is `RINGING` or `ACTIVE` and the local user is not already in that call (`src/pages/DmChat/DmChat.tsx`).
- Strengthened event typings for call events (`src/store/interfaces/callEvents.interface.ts`) and adapted `ActiveCallResponse` / participant types to match backend DTOs (`src/api/interfaces/ActiveCallResponse.ts`, `src/api/interfaces/CallParticipantResponse.ts`).

### Testing
- Ran `npm run build` which failed due to pre-existing TypeScript errors in unrelated areas of the repo, so build could not complete end-to-end. (failure)
- Ran `npm run lint` which failed because repository is missing the expected ESLint top-level configuration file, so lint could not run successfully. (failure)
- Performed a focused TypeScript check (`npx tsc --noEmit` filtered to touched files) and did not find new type errors in the modified files; changed files compile cleanly in isolation. (passed for modified files)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a383bbb527c832eac4f0676e0dd81dc)